### PR TITLE
add github action to build and push image to quay

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -1,0 +1,103 @@
+name: image-build
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main]
+    tags:
+      - v*
+
+jobs:
+  build-and-push-images:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - registry: quay.io
+            repository: tkm
+            image: operator
+            dockerfile: ./Containerfile.tkm-operator
+            context: .
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+          - registry: quay.io
+            repository: tkm
+            image: agent
+            dockerfile: ./Containerfile.tkm-agent
+            context: .
+            tags: |
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha,format=long
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+    name: Build Image (${{ matrix.image.image }})
+    steps:
+      - name: Checkout TKM
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Login to quay.io/tkm
+        uses: redhat-actions/podman-login@v1
+        if: ${{ github.event_name == 'push' && matrix.image.repository == 'tkm'}}
+        with:
+          registry: ${{ matrix.image.registry }}
+          username: ${{ secrets.TKM_USERNAME }}
+          password: ${{ secrets.TKM_ROBOT_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for image
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ matrix.image.registry }}/${{ matrix.image.repository }}/${{ matrix.image.image }}
+          tags: ${{ matrix.image.tags }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set push flag
+        id: set-push
+        run: |
+          if [ ${{ github.event_name }} == 'push' ]; then
+            echo "push_flag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_flag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        id: build-push-image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64
+          #platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
+          push: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ matrix.image.dockerfile }}
+          build-args: BUILDPLATFORM=linux/amd64
+          context: ${{ matrix.image.context }}
+
+      - name: Sign the images with GitHub OIDC Token
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          readarray -t tags <<<"${{ steps.meta.outputs.tags }}"
+          for tag in ${tags[@]}; do
+            cosign sign -y "${tag}@${{ steps.build-push-image.outputs.digest }}"
+          done


### PR DESCRIPTION
Add a github workflow that will build and push the Agent and Operator images to quay.io/tkm/. on each pull request.