### PR TITLE
quay login and image push should only run on push

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -1,5 +1,7 @@
 name: image-build
 
+# On Pull Requests, only want to build image to make sure build isn't broken, don't push to quay.io.
+# On Push to main (in repo, not forks), want to build and push image to quay.io.
 on:
   pull_request:
     branches: ["*"]
@@ -48,15 +50,37 @@ jobs:
 
     name: Build Image (${{ matrix.image.image }})
     steps:
+      # Set a `push_flag`. This is only true if the github action is a push and the repository
+      # organization is `redhat-et`. This keeps credential fails from occurring on push to forks.
+      - name: Set push flag
+        id: set-push
+        run: |
+          if [ ${{ github.event_name }} == 'push' && ${{ github.repository_owner }} == 'redhat-et' ]; then
+            echo "push_flag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_flag=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout TKM
         uses: actions/checkout@v4
 
       - name: Install cosign
+        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         uses: sigstore/cosign-installer@v3.5.0
+
+      # TO BE REMOVED: Leaving in to verify values on a push to a fork of repository.
+      - name: Debug
+        run: |
+          echo "The event that triggered this workflow is ${{ github.event_name }}."
+          echo "The matrix.image.repository is ${{ matrix.image.repository }}."
+          echo "The ref_name is: ${{ github.ref_name }}"
+          echo "The head_ref branch is: ${{ github.head_ref }}"
+          echo "The organization is: ${{ github.repository_owner }}"
+          echo "The PUSH_FLAG is: ${{ fromJSON(steps.set-push.outputs.push_flag) }}"
 
       - name: Login to quay.io/tkm
         uses: redhat-actions/podman-login@v1
-        if: ${{ github.event_name == 'push' && matrix.image.repository == 'tkm'}}
+        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         with:
           registry: ${{ matrix.image.registry }}
           username: ${{ secrets.TKM_USERNAME }}
@@ -72,15 +96,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Set push flag
-        id: set-push
-        run: |
-          if [ ${{ github.event_name }} == 'push' ]; then
-            echo "push_flag=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "push_flag=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build and push
         id: build-push-image
         uses: docker/build-push-action@v5
@@ -95,7 +110,7 @@ jobs:
           context: ${{ matrix.image.context }}
 
       - name: Sign the images with GitHub OIDC Token
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         run: |
           readarray -t tags <<<"${{ steps.meta.outputs.tags }}"
           for tag in ${tags[@]}; do


### PR DESCRIPTION
CI on forks are failing because the quay.io login is running and the fork does not have the credentials. The quay.io login was intended to only run on a push to main on redhat-et, not on a push to a fork.