### PR TITLE
process configMap values

### DIFF
--- a/Containerfile.gkm-csi
+++ b/Containerfile.gkm-csi
@@ -39,4 +39,4 @@ ENV PATH="$PATH:/usr/sbin"
 # Run as non-root user
 USER 65532:65532
 
-ENTRYPOINT ["gkm-csi-plugin", "--nogpu"]
+ENTRYPOINT ["gkm-csi-plugin"]

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,9 @@ deploy-on-kind: manifests kustomize deploy-cert-manager ## Deploy operator and a
 	cd config/agent && $(KUSTOMIZE) edit set image quay.io/gkm/agent=${AGENT_IMG}
 	cd config/csi-plugin && $(KUSTOMIZE) edit set image quay.io/gkm/gkm-csi-plugin=${CSI_IMG}
 	cd config/configMap && \
-	  $(SED) -e 's@gkm\.agent\.image=.*@gkm.agent.image=$(AGENT_IMG)@' \
+	  $(SED) \
+	      -e '/literals:/a\  - gkm.nogpu=true' \
+	      -e 's@gkm\.agent\.image=.*@gkm.agent.image=$(AGENT_IMG)@' \
 	      -e 's@gkm\.csi\.image=.*@gkm.csi.image=$(CSI_IMG)@' \
 		  kustomization.yaml.env > kustomization.yaml
 	$(KUSTOMIZE) build config/kind-gpu | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -112,11 +112,6 @@ Pod Spec Highlights:
   The `make run-on-kind` command adds this label to node `kind-gpu-sim-worker`.
   This is help monitor logs while applying the pod.
 
-> **NOTE:** GKM is still a work in progress and the Agent and Operator are
-> deployed but aren't coded up to reconcile the CRDs.
-> To test, the OCI Image needs to be manually extracted to the node.
-> This is a temporary step.
-
 Because of the Node Selector, the test pod will be launched on node
 `kind-gpu-sim-worker`. Determine the CSI Plugin instant running on this node:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -42,8 +41,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme = runtime.NewScheme()
 )
 
 func init() {
@@ -54,12 +52,27 @@ func init() {
 }
 
 func main() {
+	// Process inputs from Environment Variables. These are set in the Operator Deployment Yaml by pulling
+	// values from the gkm-config ConfigMap Object.
+	logLevel := os.Getenv("GO_LOG")
+	setupLog := utils.InitializeLogging(logLevel, "setup", flag.CommandLine)
+	setupLog.Info("Logging", "Level", logLevel)
+
+	noGpu := false
+	tmpNoGpuStr := os.Getenv("NO_GPU")
+	if tmpNoGpuStr == "true" {
+		noGpu = true
+		setupLog.Info("No-GPU set to true", "noGpu", noGpu)
+	}
+
+	// Process inputs from Commandline
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -70,13 +83,7 @@ func main() {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -146,9 +153,10 @@ func main() {
 	}
 
 	if err = (&gkmoperator.GKMConfigMapReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		CsiDriverYamlFile: utils.CsiDriverYamlFile,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		CsiDriverYamlFile:   utils.CsiDriverYamlFile,
+		CsiDriverRegistered: false,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GKMConfigMap")
 		os.Exit(1)

--- a/config/agent/gkm-agent.yaml
+++ b/config/agent/gkm-agent.yaml
@@ -25,8 +25,16 @@ spec:
           capabilities:
             add: ["CAP_DAC_OVERRIDE", "CAP_FOWNER"]
         env:
+          - name: NO_GPU
+            valueFrom:
+              configMapKeyRef:
+                name: gkm-config
+                key: gkm.nogpu
           - name: GO_LOG
-            value: info
+            valueFrom:
+              configMapKeyRef:
+                name: gkm-config
+                key: gkm.agent.log.level
           - name: KUBE_NODE_NAME
             valueFrom:
               fieldRef:

--- a/config/configMap/configMap.yaml
+++ b/config/configMap/configMap.yaml
@@ -4,9 +4,10 @@ metadata:
   name: config
   namespace: gkm-system
 data:
+  ## Can be set to "info", "debug", or "trace". Not processed at runtime.
+  gkm.operator.log.level: info
+  gkm.agent.log.level: info
+  gkm.csi.log.level: info
   ## Can be configured at runtime
   gkm.agent.image: quay.io/gkm/agent:latest
   gkm.csi.image: quay.io/gkm/gkm-csi-plugin:latest
-  ## Can be set to "info", "debug", or "trace"
-  gkm.agent.log.level: info
-  gkm.csi.log.level: info

--- a/config/csi-plugin/gkm-csi-plugin.yaml
+++ b/config/csi-plugin/gkm-csi-plugin.yaml
@@ -37,8 +37,16 @@ spec:
           image: quay.io/gkm/gkm-csi-plugin:latest
           imagePullPolicy: "Always"
           env:
+            - name: NO_GPU
+              valueFrom:
+                configMapKeyRef:
+                  name: gkm-config
+                  key: gkm.nogpu
             - name: GO_LOG
-              value: info
+              valueFrom:
+                configMapKeyRef:
+                  name: gkm-config
+                  key: gkm.operator.log.level
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: KUBE_NODE_NAME

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,19 +65,30 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
+      - name: manager
+        command:
         - /operator
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: quay.io/gkm/operator:latest
         imagePullPolicy: IfNotPresent
-        name: manager
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - "ALL"
+        env:
+          - name: NO_GPU
+            valueFrom:
+              configMapKeyRef:
+                name: gkm-config
+                key: gkm.nogpu
+          - name: GO_LOG
+            valueFrom:
+              configMapKeyRef:
+                name: gkm-config
+                key: gkm.operator.log.level
         livenessProbe:
           httpGet:
             path: /healthz

--- a/csi-plugin/main.go
+++ b/csi-plugin/main.go
@@ -4,57 +4,51 @@ import (
 	"context"
 	"flag"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/redhat-et/GKM/pkg/database"
 	"github.com/redhat-et/GKM/pkg/gkm-csi-plugin/driver"
 
 	"github.com/redhat-et/GKM/pkg/utils"
 )
 
-var versionInfo = flag.Bool("version", false, "Print the driver version")
-var testMode = flag.Bool("test", false, "Flag to indicate in a Test Mode. Creates a stubbed out Kubelet Server")
-
-//var noGpu = flag.Bool("nogpu", false, "Flag to indicate in a test scenario and GPU is not present")
-
 func main() {
-	// Process input data through environment variables
+	// Process inputs from Environment Variables. These are set in the CSI DaemonSet Yaml by pulling
+	// values from the gkm-config ConfigMap Object.
+
+	// Setup logging before anything else so code can log errors.
+	logLevel := os.Getenv("GO_LOG")
+	log := utils.InitializeLogging(logLevel, "setup", nil)
+	log.Info("Logging", "Level", logLevel)
+
 	nodeName := strings.TrimSpace(os.Getenv("KUBE_NODE_NAME"))
 	if nodeName == "" {
 		nodeName = "local"
 	}
+
 	ns := strings.TrimSpace(os.Getenv("GKM_NAMESPACE"))
 	if ns == "" {
 		ns = "default"
 	}
-	logLevel := strings.TrimSpace(os.Getenv("GO_LOG"))
-	if logLevel == "" {
-		logLevel = "info"
-	}
+
 	socketFilename := os.Getenv("CSI_ENDPOINT")
 	if socketFilename == "" {
 		socketFilename = utils.DefaultSocketFilename
 	}
 
 	// Parse command line variables
+	var versionInfo = flag.Bool("version", false, "Print the driver version")
+	var testMode = flag.Bool("test", false, "Flag to indicate in a Test Mode. Creates a stubbed out Kubelet Server")
 	flag.Parse()
-
-	// Setup logging before anything else so code can log errors.
-	log := database.InitializeLogging(logLevel)
 
 	// Process command line variables
 	if *versionInfo {
 		log.Info("CSI Driver", "Version", driver.Version)
 		return
 	}
-
-	_, err := exec.LookPath("tcv")
-	log.Info("cmdExists", "cmd", utils.TcvBinary, "err", err)
 
 	// Setup CSI Driver, which receives CSI requests from Kubelet
 	d, err := driver.NewDriver(log, nodeName, ns, socketFilename, utils.DefaultCacheDir, *testMode)

--- a/internal/controller/gkm-agent/namespace_gkmcache_controller.go
+++ b/internal/controller/gkm-agent/namespace_gkmcache_controller.go
@@ -46,6 +46,7 @@ type GKMCacheReconciler struct {
 	Logger   logr.Logger
 	CacheDir string
 	NodeName string
+	NoGpu    bool
 
 	currCache     *gkmv1alpha1.GKMCache
 	currCacheNode *gkmv1alpha1.GKMCacheNode
@@ -195,6 +196,7 @@ func (r *GKMCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					r.currCache.Name,
 					r.currCache.Spec.Image,
 					digest,
+					r.NoGpu,
 					r.Logger,
 				); err != nil {
 					// Error returned calling MCV to extract the Cache.

--- a/pkg/database/cache_test.go
+++ b/pkg/database/cache_test.go
@@ -70,11 +70,13 @@ func TestExtractCache(t *testing.T) {
 			require.NoError(t, err)
 		}()
 
+		noGpu := true
+
 		// Instance 1: Cluster Scoped
 		t1 := TestData{
 			CrNamespace: "",
 			CrName:      "yellowKernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -82,7 +84,7 @@ func TestExtractCache(t *testing.T) {
 		t2 := TestData{
 			CrNamespace: "",
 			CrName:      "Red.Kernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -90,7 +92,7 @@ func TestExtractCache(t *testing.T) {
 		t3 := TestData{
 			CrNamespace: "blue",
 			CrName:      "blue_Kernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -98,7 +100,7 @@ func TestExtractCache(t *testing.T) {
 		t4 := TestData{
 			CrNamespace: "blue",
 			CrName:      "light-Blue-Kernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -106,7 +108,7 @@ func TestExtractCache(t *testing.T) {
 		t5 := TestData{
 			CrNamespace: "green",
 			CrName:      "greenKernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -114,7 +116,7 @@ func TestExtractCache(t *testing.T) {
 		t6 := TestData{
 			CrNamespace: "purple",
 			CrName:      "purpleKernel",
-			Digest:      "22ae699979cf58ab990960c799d32e44b1c38fc2681461f187122ea045b3cf9a",
+			Digest:      "d9cfcee43b201e1616487c15c74b7fcb387086e35feb545c4fb9126f51a20770",
 			Image:       "quay.io/gkm/vector-add-cache:rocm",
 		}
 
@@ -130,7 +132,7 @@ func TestExtractCache(t *testing.T) {
 
 		// CREATE and READ Cache
 		t.Logf("TEST: Instance 1 - Cluster - ExtractCache() - Should Succeed")
-		err = ExtractCache(t1.CrNamespace, t1.CrName, t1.Image, t1.Digest, log)
+		err = ExtractCache(t1.CrNamespace, t1.CrName, t1.Image, t1.Digest, noGpu, log)
 		t.Logf("Instance 1 - Cluster - ExtractCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
@@ -140,7 +142,7 @@ func TestExtractCache(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Logf("TEST: Instance 2 - Cluster - ExtractCache() - Same Image but different Name - Should Succeed")
-		err = ExtractCache(t2.CrNamespace, t2.CrName, t2.Image, t2.Digest, log)
+		err = ExtractCache(t2.CrNamespace, t2.CrName, t2.Image, t2.Digest, noGpu, log)
 		t.Logf("Instance 2 - Cluster - ExtractCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
@@ -150,7 +152,7 @@ func TestExtractCache(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Logf("TEST: Instance 3 - Namespace - ExtractCache() - Should Succeed")
-		err = ExtractCache(t3.CrNamespace, t3.CrName, t3.Image, t3.Digest, log)
+		err = ExtractCache(t3.CrNamespace, t3.CrName, t3.Image, t3.Digest, noGpu, log)
 		t.Logf("Instance 3 - Namespace - ExtractCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
@@ -160,7 +162,7 @@ func TestExtractCache(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Logf("TEST: Instance 4 - Namespace - ExtractCache() - Same Namespace but Different Name - Should Succeed")
-		err = ExtractCache(t4.CrNamespace, t4.CrName, t4.Image, t4.Digest, log)
+		err = ExtractCache(t4.CrNamespace, t4.CrName, t4.Image, t4.Digest, noGpu, log)
 		t.Logf("Instance 4 - Namespace - ExtractCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
@@ -170,7 +172,7 @@ func TestExtractCache(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Logf("TEST: Instance 5 - Namespace - ExtractCache() - Different Namespace - Should Succeed")
-		err = ExtractCache(t5.CrNamespace, t5.CrName, t5.Image, t5.Digest, log)
+		err = ExtractCache(t5.CrNamespace, t5.CrName, t5.Image, t5.Digest, noGpu, log)
 		t.Logf("Instance 5 - Namespace - ExtractCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
@@ -191,7 +193,7 @@ func TestExtractCache(t *testing.T) {
 		// DELETE Cache
 		t.Logf("TEST: Instance 1 - Cluster - RemoveCache() - Should Succeed")
 		_, err = RemoveCache(t1.CrNamespace, t1.CrName, t1.Digest, log)
-		t.Logf("Instance 1 - Cluster - ExtractCache() err: %v", err)
+		t.Logf("Instance 1 - Cluster - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)
@@ -201,7 +203,7 @@ func TestExtractCache(t *testing.T) {
 
 		t.Logf("TEST: Instance 2 - Cluster - RemoveCache() - Should Succeed")
 		_, err = RemoveCache(t2.CrNamespace, t2.CrName, t2.Digest, log)
-		t.Logf("Instance 2 - Cluster - ExtractCache() err: %v", err)
+		t.Logf("Instance 2 - Cluster - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)
@@ -211,7 +213,7 @@ func TestExtractCache(t *testing.T) {
 
 		t.Logf("TEST: Instance 3 - Namespace - RemoveCache() - Should Succeed")
 		_, err = RemoveCache(t3.CrNamespace, t3.CrName, t3.Digest, log)
-		t.Logf("Instance 3 - Namespace - ExtractCache() err: %v", err)
+		t.Logf("Instance 3 - Namespace - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)
@@ -221,7 +223,7 @@ func TestExtractCache(t *testing.T) {
 
 		t.Logf("TEST: Instance 4 - Namespace - RemoveCache() - Should Succeed")
 		_, err = RemoveCache(t4.CrNamespace, t4.CrName, t4.Digest, log)
-		t.Logf("Instance 4 - Namespace - ExtractCache() err: %v", err)
+		t.Logf("Instance 4 - Namespace - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)
@@ -231,7 +233,7 @@ func TestExtractCache(t *testing.T) {
 
 		t.Logf("TEST: Instance 5 - Namespace - RemoveCache() - Should Succeed")
 		_, err = RemoveCache(t5.CrNamespace, t5.CrName, t5.Digest, log)
-		t.Logf("Instance 5 - Namespace - ExtractCache() err: %v", err)
+		t.Logf("Instance 5 - Namespace - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)
@@ -241,7 +243,7 @@ func TestExtractCache(t *testing.T) {
 
 		t.Logf("TEST: Instance 6 - Namespace - RemoveCache() - Nonexistent Cache - Should Fail")
 		_, err = RemoveCache(t6.CrNamespace, t6.CrName, t6.Digest, log)
-		t.Logf("Instance 6 - Namespace - ExtractCache() err: %v", err)
+		t.Logf("Instance 6 - Namespace - RemoveCache() err: %v", err)
 		require.NoError(t, err)
 		// Read the filesystem to see if it was extracted
 		installedList, err = GetInstalledCacheList(log)

--- a/pkg/database/files.go
+++ b/pkg/database/files.go
@@ -12,10 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/mount-utils"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/redhat-et/GKM/pkg/utils"
 )
@@ -196,32 +193,4 @@ func IsDirEmpty(inputDir, ignoreFile string) bool {
 		}
 	}
 	return true // Directory is empty
-}
-
-func InitializeLogging(logLevel string) logr.Logger {
-	var opts zap.Options
-
-	// Setup logging
-	switch logLevel {
-	case "info":
-		opts = zap.Options{
-			Development: false,
-		}
-	case "debug":
-		opts = zap.Options{
-			Development: true,
-		}
-	case "trace":
-		opts = zap.Options{
-			Development: true,
-			Level:       zapcore.Level(-2),
-		}
-	default:
-		opts = zap.Options{
-			Development: false,
-		}
-	}
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-	return ctrl.Log.WithName("gkm-csi")
 }

--- a/pkg/utils/contants.go
+++ b/pkg/utils/contants.go
@@ -27,9 +27,6 @@ const (
 	// images.
 	ClusterScopedSubDir = "cluster-scoped"
 
-	// TcvBinary is the location on the host of the TCV binary.
-	TcvBinary = "tcv"
-
 	// Name of the GKM ConfigMap that is used to control how GKM is Deployed and Functions.
 	GKMConfigName = "gkm-config"
 
@@ -42,7 +39,7 @@ const (
 	// GKMCache and ClusterGKMCache Annotations
 	GMKCacheAnnotationResolvedDigest = "gkm.io/resolvedDigest"
 
-	// GKMCache and ClusterGKMCache LAbels
+	// GKMCache and ClusterGKMCache Labels
 	GMKCacheLabelHostname = "kubernetes.io/hostname"
 	GMKCacheLabelOwnedBy  = "gkm.io/ownedByCache"
 
@@ -56,6 +53,14 @@ const (
 	// NamespaceGkmCacheFinalizer is the finalizer that holds a GKMCacheNode from deletion
 	// until GkmCache is deleted and cleanup can be performed.
 	NamespaceGkmCacheFinalizer = "gkm.io.namespacegkmcachefinalizer/finalizer"
+
+	// ConfigMap Indexes
+	ConfigMapIndexOperatorLogLevel = "gkm.operator.log.level"
+	ConfigMapIndexAgentImage       = "gkm.agent.image"
+	ConfigMapIndexAgentLogLevel    = "gkm.agent.log.level"
+	ConfigMapIndexCsiImage         = "gkm.csi.image"
+	ConfigMapIndexCsiLogLevel      = "gkm.csi.log.level"
+	ConfigMapIndexNoGpu            = "gkm.nogpu"
 
 	// Duration for Kubernetes to Retry a failed request
 	RetryDurationOperator = 5 * time.Second

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func InitializeLogging(logLevel, component string, commandLine *flag.FlagSet) logr.Logger {
+	var opts zap.Options
+
+	// Setup logging
+	switch strings.TrimSpace(logLevel) {
+	case "info":
+		opts = zap.Options{
+			Development: false,
+		}
+	case "debug":
+		opts = zap.Options{
+			Development: true,
+		}
+	case "trace":
+		opts = zap.Options{
+			Development: true,
+			Level:       zapcore.Level(-2),
+		}
+	default:
+		// Default to Info
+		opts = zap.Options{
+			Development: false,
+		}
+	}
+
+	if commandLine != nil {
+		opts.BindFlags(commandLine)
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	return ctrl.Log.WithName(component)
+}


### PR DESCRIPTION
Process the LogLevels and NoGpu from the ConfigMap by passing the values as Enviroment Variables from the deployment yamls. If the ConfigMap is changed on the fly, these values will NOT be reapplied. May look into that in the future.

The CSI Driver registration is also in the ConfigMap processing file. It is a one and done and didn't need it's own controller. Reworked the logic slightly so it's contained in it's own functions and less intrusive to the ConfigMap processing.

Upstream CI is failing because the image being used in the unit tests, "quay.io/gkm/vector-add-cache:rocm" was updated and a new SHA was created. Longer term, need a way to lock the SHA, or the unit tests don't really pull and extract an image. But that is for aother day, just fix the hardcoded SHA for now.