### PR TITLE
enhance undeploy to cleanup ClusterGKMCache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,9 +283,9 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 ##@ Deployment
 .PHONY: prepare-deploy
 prepare-deploy:
-	cd config/operator && $(KUSTOMIZE) edit set image $(REPO)/operator=${OPERATOR_IMG}
-	cd config/agent && $(KUSTOMIZE) edit set image $(REPO)/agent=${AGENT_IMG}
-	cd config/csi-plugin && $(KUSTOMIZE) edit set image $(REPO)/gkm-csi-plugin=${CSI_IMG}
+	cd config/operator && $(KUSTOMIZE) edit set image quay.io/gkm/operator=${OPERATOR_IMG}
+	cd config/agent && $(KUSTOMIZE) edit set image quay.io/gkm/agent=${AGENT_IMG}
+	cd config/csi-plugin && $(KUSTOMIZE) edit set image quay.io/gkm/gkm-csi-plugin=${CSI_IMG}
 ifdef NO_GPU
 	cd config/configMap && \
 	  $(SED) \

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -2,10 +2,260 @@
 
 # Control script behavior
 DEBUG=${DEBUG:-false}
+WORK=${WORK:-true}
+
+ABORT_FLAG=false
 
 # Process input flags
 FORCE_FLAG=false
 
+verify_kubectl() {
+  # Test for kubectl or oc
+  kubectl version  &>/dev/null
+  if [ $? != 0 ]; then
+    oc version  &>/dev/null
+    if [ $? != 0 ]; then
+      echo "ERROR: Either \`kubectl\` or \`oc\` must be installed. Exiting ..."
+      echo
+      exit 1
+    fi
+
+    alias kubectl="oc"
+
+    if [[ "$DEBUG" == true ]]; then
+      echo "oc detected"
+    fi
+  else
+    if [[ "$DEBUG" == true ]]; then
+      echo "kubectl detected"
+    fi
+  fi
+}
+
+abort_msg_and_exit() {
+  echo
+  echo "GKMCache and/or ClusterGKMCache instances still exist. Cannot undeploy GKM."
+  echo "Remove all GKMCache and ClusterGKMCache instances along with pods using the cache"
+  echo "and retry, or run the force version of the undeploy command."
+  echo
+  echo "Aborting undeploy request."
+  echo
+  exit 1
+}
+
+# Determine if any GKMCache instances exist and cleanup if force is set.
+process_gkm_cache() {
+  if [[ "$DEBUG" == true ]]; then
+    echo "Process GKMCache Instances"
+  fi
+
+  # Retrieve the Namespaces the GKMCaches are created in.
+  GKM_CACHE_NAMESPACE_OUTPUT=$(kubectl get gkmcaches -A --no-headers -o custom-columns=NAMESPACE:.metadata.namespace)
+  if [[ $? == 0 ]] && [[ "$GKM_CACHE_NAMESPACE_OUTPUT" != "" ]]; then
+    if [[ "$DEBUG" == true ]]; then
+      echo "GKMCache instance Exist!"
+      echo "${GKM_CACHE_NAMESPACE_OUTPUT}"
+    fi
+
+    if [[ "$FORCE_FLAG" == false ]]; then
+      # Force flag is not set and GKMCache instances exist. Print them and abort.
+      echo
+      while IFS= read -r GKM_CACHE_NAMESPACE; do
+        echo "Need to delete GKMCache \"$GKM_CACHE_NAMESPACE\" and any pods using the associated cache."
+      done <<< "$GKM_CACHE_NAMESPACE_OUTPUT"
+
+      # Since force flag is not set, skip the abort, but remember via flag. This will let
+      # ClusterGKMCache print any instances to help user with cleanup.
+      ABORT_FLAG=true
+    else
+      # Force flag is set. Because workload is contained in a Namespace, delete any workload namespaces.
+      echo "Attempt to remove GKMCache workload namespaces:"
+
+      # Loop through GKMCache Namespaces and attempt to delete Namespace.
+      while IFS= read -r GKM_CACHE_NAMESPACE; do
+        if [[ "$GKM_CACHE_NAMESPACE" == "default" ]]; then
+          echo "Can't handle namespace \"${GKM_CACHE_NAMESPACE}\" yet, exiting"
+          abort_msg_and_exit
+        else
+          echo
+          echo "Deleting namespace \"$GKM_CACHE_NAMESPACE\":"
+          if [[ "$WORK" == true ]]; then
+            kubectl delete namespace --ignore-not-found=true ${GKM_CACHE_NAMESPACE}
+          fi
+          if [ $? == 0 ]; then
+            echo "Deleting namespace \"$GKM_CACHE_NAMESPACE\" was successful."
+          else
+            echo "Deleting namespace \"$GKM_CACHE_NAMESPACE\" was NOT successful."
+            abort_msg_and_exit
+          fi
+        fi
+      done <<< "$GKM_CACHE_NAMESPACE_OUTPUT"
+
+      if [[ "$WORK" == true ]]; then
+        # All GKMCache Namespaces should have been deleted. Verify all GKMCache are deleted.
+        # Retrieve the names of all GKMCaches.
+        GKM_CACHE_NAME_OUTPUT=$(kubectl get gkmcaches -A --no-headers -o custom-columns=NAME:.metadata.name)
+        if [[ $? == 0 ]] && [[ "$GKM_CACHE_NAME_OUTPUT" != "" ]]; then
+          echo
+          echo "GKMCache instances still exist after Namespace deletion!"
+          echo "${GKM_CACHE_NAME_OUTPUT}"
+
+          abort_msg_and_exit
+        else
+          echo
+          echo "GKMCache cleanup complete."
+        fi
+      else
+        echo
+        echo "GKMCache cleanup complete."
+      fi
+    fi
+  else
+    if [[ "$DEBUG" == true ]]; then
+      echo "NO GKMCache instance Exist!"
+    fi
+  fi
+}
+
+# Determine if any ClusterGKMCache instances exist and cleanup if force is set.
+process_cluster_gkm_cache() {
+  if [[ "$DEBUG" == true ]]; then
+    echo "Process ClusterGKMCache Instances"
+  fi
+
+  # Retrieve the Name of any ClusterGKMCaches that are created.
+  CLUSTER_GKM_CACHE_NAME_OUTPUT=$(kubectl get clustergkmcaches --no-headers -o custom-columns=NAME:.metadata.name)
+  if [[ $? == 0 ]] && [[ "$CLUSTER_GKM_CACHE_NAME_OUTPUT" != "" ]]; then
+    if [[ "$DEBUG" == true ]]; then
+      echo "Cluster GKM Cache instances Exist!"
+      echo "${CLUSTER_GKM_CACHE_NAME_OUTPUT}"
+    fi
+
+    if [[ "$FORCE_FLAG" == false ]]; then
+      # Force flag is not set and ClusterGKMCache instances exist. Print them and abort.
+      echo
+      while IFS= read -r CLUSTER_GKM_CACHE_NAME; do
+        echo "Need to delete ClusterGKMCache \"$CLUSTER_GKM_CACHE_NAME\" and any pods using the associated cache."
+      done <<< "$CLUSTER_GKM_CACHE_NAME_OUTPUT"
+
+      # Since force flag is not set, skip the abort, but remember via flag. This will let
+      # GKMCache print any instances to help user with cleanup.
+      ABORT_FLAG=true
+    else
+      # Force flag is set, the determine if any ClusterGKMCacheNode instances exist.
+      # This is where pod usages is returned and will be used in the cleanup.
+      CLUSTER_GKM_CACHE_NODE_OUTPUT=$(kubectl get clustergkmcachenodes --no-headers -o custom-columns=NAME:.metadata.name)
+      if [[ $? == 0 ]] && [[ "$CLUSTER_GKM_CACHE_NODE_OUTPUT" != "" ]]; then
+        if [[ "$DEBUG" == true ]]; then
+          echo "Cluster GKM Cache Node instances Exist!"
+          echo "${CLUSTER_GKM_CACHE_NODE_OUTPUT}"
+        fi
+
+        # Because workload is contained in a Namespace, loop through workload Namespaces
+        # and attempt to delete Namespace.
+        echo
+        echo "Attempt to remove ClusterGKMCache workload namespaces:"
+
+        while IFS= read -r CLUSTER_GKM_CACHE_NODE; do
+          POD_NAMESPACE_OUTPUT=$(kubectl get clustergkmcachenode $CLUSTER_GKM_CACHE_NODE -o yaml | grep podNamespace | awk -F' ' '{print $2}')
+          if [[ $? == 0 ]] && [[ "$POD_NAMESPACE_OUTPUT" != "" ]]; then
+
+            if [[ "$DEBUG" == true ]]; then
+              echo "Pod namespace instances Exist!"
+              echo "${POD_NAMESPACE_OUTPUT}"
+            fi
+
+            while IFS= read -r POD_NAMESPACE; do
+              if [[ "$POD_NAMESPACE" == "default" ]]; then
+                echo "Can't handle namespace \"${POD_NAMESPACE}\" yet, exiting"
+                exit 1
+              else
+                echo
+                echo "Delete namespace \"$POD_NAMESPACE\" to remove any pods using the associated cluster cache:"
+                if [[ "$WORK" == true ]]; then
+                  kubectl delete namespace --ignore-not-found=true ${POD_NAMESPACE}
+                fi
+                if [ $? == 0 ]; then
+                  echo "Deleting namespace \"$POD_NAMESPACE\" was successful."
+                else
+                  echo "Deleting namespace \"$POD_NAMESPACE\" was NOT successful."
+                  abort_msg_and_exit
+                fi
+              fi
+            done <<< "$POD_NAMESPACE_OUTPUT"
+
+          else
+            if [[ "$DEBUG" == true ]]; then
+              echo
+              echo "NO Pods exist in ClusterGKMCache  \"$CLUSTER_GKM_CACHE_NODE\" instance."
+            fi
+          fi
+        done <<< "$CLUSTER_GKM_CACHE_NODE_OUTPUT"
+      else
+        if [[ "$DEBUG" == true ]]; then
+          echo
+          echo "NO ClusterGKMCacheNodes instance Exist!"
+        fi
+      fi
+
+      # Now that workload pods are cleaned up, attempt to delete ClusterGKMCache instances.
+      while IFS= read -r CLUSTER_GKM_CACHE_NAME; do
+        echo
+        echo "Deleting ClusterGKMCache \"$CLUSTER_GKM_CACHE_NAME\":"
+        if [[ "$WORK" == true ]]; then
+          kubectl delete clustergkmcache ${CLUSTER_GKM_CACHE_NAME}
+        fi
+        if [ $? == 0 ]; then
+          echo "Deleting ClusterGKMCache \"$CLUSTER_GKM_CACHE_NAME\" was successful."
+        else
+          echo "Deleting ClusterGKMCache \"$CLUSTER_GKM_CACHE_NAME\" was NOT successful."
+          abort_msg_and_exit
+        fi
+      done <<< "$CLUSTER_GKM_CACHE_NAME_OUTPUT"
+
+      if [[ "$WORK" == true ]]; then
+        # All ClusterGKMCache instances should have been deleted. Verify they all are deleted.
+        # Retrieve the names of all ClusterGKMCaches.
+        CLUSTER_GKM_CACHE_NAME_OUTPUT=$(kubectl get clustergkmcaches --no-headers -o custom-columns=NAME:.metadata.name)
+        if [[ $? == 0 ]] && [[ "$CLUSTER_GKM_CACHE_NAME_OUTPUT" != "" ]]; then
+          echo
+          echo "ClusterGKMCache instances still exist after deletion attempt!"
+          echo "${CLUSTER_GKM_CACHE_NAME_OUTPUT}"
+
+          abort_msg_and_exit
+        else
+          echo
+          echo "ClusterGKMCache cleanup complete."
+        fi
+      else
+        echo
+        echo "ClusterGKMCache cleanup complete."
+      fi
+    fi
+  else
+    if [[ "$DEBUG" == true ]]; then
+      echo
+      echo "NO ClusterGKMCache instance Exist!"
+    fi
+  fi
+
+  # Determine if any ClusterGKMCache instances exist.
+  CLUSTER_GKM_CACHE_OUTPUT=$(kubectl get clustergkmcaches --no-headers -o custom-columns=NAME:.metadata.name)
+  if [[ $? == 0 ]] && [[ "$CLUSTER_GKM_CACHE_OUTPUT" != "" ]]; then
+    if [[ "$DEBUG" == true ]]; then
+      echo
+      echo "Cluster GKM Cache instances Exist!"
+      echo "${CLUSTER_GKM_CACHE_OUTPUT}"
+    fi
+  fi
+}
+
+#
+# Main
+#
+verify_kubectl
+
+# Process Input Variables
 case "$1" in
   "force"|"-force"|"--force")
     FORCE_FLAG=true
@@ -18,113 +268,17 @@ case "$1" in
     ;;
 esac
 
-# Test for kubectl or oc
-kubectl version  &>/dev/null
-if [ $? != 0 ]; then
-  oc version  &>/dev/null
-  if [ $? != 0 ]; then
-    echo "ERROR: Either \`kubectl\` or \`oc\` must be installed. Exiting ..."
-    echo
-    exit 1
-  fi
+process_gkm_cache
+echo
+process_cluster_gkm_cache
+echo
 
-  alias kubectl="oc"
-
-  if [[ "$DEBUG" == true ]]; then
-    echo "oc detected"
-  fi
-else
-  if [[ "$DEBUG" == true ]]; then
-    echo "kubectl detected"
-  fi
+if [[ "$ABORT_FLAG" == true ]]; then
+  abort_msg_and_exit
 fi
 
-GKM_CACHE_OUTPUT=$(kubectl get gkmcaches -A --no-headers -o custom-columns=NAMESPACE:.metadata.namespace)
-if [[ $? == 0 ]] && [[ "$GKM_CACHE_OUTPUT" != "" ]]; then
-  if [[ "$DEBUG" == true ]]; then
-    echo "GKMCache instance Exist!"
-    echo "${GKM_CACHE_OUTPUT}"
-  fi
-
-  # If no force flag, then exit because GKMCache instances still exist.
-  if [[ "$FORCE_FLAG" == false ]]; then
-    echo
-    while IFS= read -r line; do
-      echo "Need to delete GKMCache \"$line\" and any pods using the associated cache."
-    done <<< "$GKM_CACHE_OUTPUT"
-
-    echo
-    echo "GKMCache instances still exist. Cannot undeploy GKM. Remove all GKMCache and ClusterGKMCache"
-    echo "instances and retry, or run the force version of the undeploy command."
-    echo
-    echo "Aborting undeploy request."
-    echo
-    exit 1
-  else
-    # Force flag is set. Because workload is contained in a Namespace, delete any workload namespaces.
-    echo "Attempt to remove workload namespaces:"
-
-    while IFS= read -r line; do
-      if [[ "$line" == "default" ]]; then
-        echo "Can't handle namespace \"${line}\" yet, exiting"
-        exit 1
-      else
-        echo
-        echo "Deleting namespace \"$line\":"
-        kubectl delete namespace ${line}
-        if [ $? == 0 ]; then
-          echo "Deleting namespace \"$line\" was successful."
-        else
-          echo "Deleting namespace \"$line\" was NOT successful."
-          exit 1
-        fi
-      fi
-    done <<< "$GKM_CACHE_OUTPUT"
-    echo
-  fi
-else
-  if [[ "$DEBUG" == true ]]; then
-    echo "NO GKMCache instance Exist!"
-  fi
-fi
-
-CLUSTER_GKM_CACHE_OUTPUT=$(kubectl get clustergkmcaches -A --no-headers -o custom-columns=NAME:.metadata.name)
-if [[ $? == 0 ]] && [[ "$CLUSTER_GKM_CACHE_OUTPUT" != "" ]]; then
-  if [[ "$DEBUG" == true ]]; then
-    echo "Cluster GKM Cache instance Exist!"
-    echo "${CLUSTER_GKM_CACHE_OUTPUT}"
-  fi
-
-  # If no force flag, then exit because ClusterGKMCache instances still exist.
-  if [[ "$FORCE_FLAG" == false ]]; then
-    echo
-    while IFS= read -r line; do
-      echo "Need to delete ClusterGKMCache \"$line\" and any pods using the associated cache."
-    done <<< "$CLUSTER_GKM_CACHE_OUTPUT"
-
-    echo
-    echo "ClusterGKMCache instances still exist. Cannot undeploy GKM. Remove all GKMCache and ClusterGKMCache"
-    echo "instances and retry, or run the force version of the undeploy command."
-    echo
-    echo "Aborting undeploy request."
-    echo
-    exit 1
-  else
-    echo
-    while IFS= read -r line; do
-      echo "Need to delete ClusterGKMCache \"$line\" and any pods using the associated cache."
-    done <<< "$CLUSTER_GKM_CACHE_OUTPUT"
-
-    echo
-    echo "Can't handle ClusterGKMCache cleanup yet, exiting"
-    echo
-    exit 1
-  fi
-else
-  if [[ "$DEBUG" == true ]]; then
-    echo "NO ClusterGKMCache instance Exist!"
-  fi
-fi
-
+echo
 echo "GKM can now be safely uninstalled."
+echo
+
 exit 0


### PR DESCRIPTION
The original undeploy PR did not properly cleanup ClusterGKMCache instances because it was more work to walk the ClusterGKMCacheNodes and pull the pods namespaces. This PR follows up and does this extra work. The previous PR also always ran a force undeploy. This has now been moved to a separate command:

* make undeploy: Fails if any GKMCache or ClusterGKMCache instances still exist.
* make undeploy-force: Attempts to delete assicated GKMCache namespace, which should delete all pods and GKMCache instances that exists. For ClusterGKMCache, attempts to delete the pod namespaces that are using the ClusterGKMCache, then deletes the ClusterGKMCache instance.
* make undeploy-on-kind: Fails if any GKMCache or ClusterGKMCache instances still exist.
* make undeploy-on-kind-force: Attempts to delete GKMCache and ClusterGKMCache instances same as make undeploy-force.