### PR TITLE
add support for deleting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,9 +351,11 @@ deploy-examples: ## Deploy the examples to the K8s cluster specified in ~/.kube/
 .PHONY: undeploy-examples
 undeploy-examples: ## Undeploy the examples from the K8s cluster specified in ~/.kube/config.
 	@echo "Remove Namespace based GKMCache"
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/namespace/
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/namespace/RWO/
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/namespace/ROX/
 	@echo "Remove Cluster based ClusterGKMCache"
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/cluster/
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/cluster/RWO/
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f examples/cluster/ROX/
 
 ##@ Kind Cluster Management
 KIND_CLUSTER_NAME ?= kind-gpu-sim

--- a/agent/main.go
+++ b/agent/main.go
@@ -170,6 +170,7 @@ func main() {
 		gkmv1alpha1.GKMCache,
 		gkmv1alpha1.GKMCacheList,
 		gkmv1alpha1.GKMCacheNode,
+		gkmv1alpha1.GKMCacheNodeList,
 	]{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
@@ -192,6 +193,7 @@ func main() {
 		gkmv1alpha1.ClusterGKMCache,
 		gkmv1alpha1.ClusterGKMCacheList,
 		gkmv1alpha1.ClusterGKMCacheNode,
+		gkmv1alpha1.ClusterGKMCacheNodeList,
 	]{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),

--- a/api/v1alpha1/clustergkmcache_types.go
+++ b/api/v1alpha1/clustergkmcache_types.go
@@ -48,6 +48,7 @@ import (
 // +kubebuilder:printcolumn:name="Node-Not-In-Use",type=string,JSONPath=`.status.counts.nodeNotInUseCnt`
 // +kubebuilder:printcolumn:name="Node-Error",type=string,JSONPath=`.status.counts.nodeErrorCnt`
 // +kubebuilder:printcolumn:name="Pod-Running",type=string,JSONPath=`.status.counts.podRunningCnt`
+// +kubebuilder:printcolumn:name="Pod-Deleting",type=string,JSONPath=`.status.counts.podDeletingCnt`
 // +kubebuilder:printcolumn:name="Pod-Outdated",type=string,JSONPath=`.status.counts.podOutdatedCnt`
 // +kubebuilder:printcolumn:name="Last=Updated",type=string,priority=1,JSONPath=".status.lastUpdated"
 type ClusterGKMCache struct {
@@ -121,7 +122,7 @@ func (cache ClusterGKMCache) GetImage() string {
 }
 
 func (cache ClusterGKMCache) GetStatus() *GKMCacheStatus {
-	return &cache.Status
+	return cache.Status.DeepCopy()
 }
 
 func (cache ClusterGKMCache) GetClientObject() client.Object {

--- a/api/v1alpha1/clustergkmcachenode_types.go
+++ b/api/v1alpha1/clustergkmcachenode_types.go
@@ -38,6 +38,7 @@ import (
 // +kubebuilder:printcolumn:name="Node-Not-In-Use",type=string,JSONPath=`.status.counts.nodeNotInUseCnt`
 // +kubebuilder:printcolumn:name="Node-Error",type=string,JSONPath=`.status.counts.nodeErrorCnt`
 // +kubebuilder:printcolumn:name="Pod-Running",type=string,JSONPath=`.status.counts.podRunningCnt`
+// +kubebuilder:printcolumn:name="Pod-Deleting",type=string,JSONPath=`.status.counts.podDeletingCnt`
 // +kubebuilder:printcolumn:name="Pod-Outdated",type=string,JSONPath=`.status.counts.podOutdatedCnt`
 type ClusterGKMCacheNode struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -80,7 +81,7 @@ func (cacheNode ClusterGKMCacheNode) GetLabels() map[string]string {
 }
 
 func (cacheNode ClusterGKMCacheNode) GetStatus() *GKMCacheNodeStatus {
-	return &cacheNode.Status
+	return cacheNode.Status.DeepCopy()
 }
 
 func (cacheNode ClusterGKMCacheNode) GetNodeName() string {

--- a/api/v1alpha1/gkmcache_types.go
+++ b/api/v1alpha1/gkmcache_types.go
@@ -46,6 +46,7 @@ import (
 // +kubebuilder:printcolumn:name="Node-Error",type=string,JSONPath=`.status.counts.nodeErrorCnt`
 // +kubebuilder:printcolumn:name="Pod-Running",type=string,JSONPath=`.status.counts.podRunningCnt`
 // +kubebuilder:printcolumn:name="Pod-Outdated",type=string,JSONPath=`.status.counts.podOutdatedCnt`
+// +kubebuilder:printcolumn:name="Pod-Deleting",type=string,JSONPath=`.status.counts.podDeletingCnt`
 // +kubebuilder:printcolumn:name="Last=Updated",type=string,priority=1,JSONPath=".status.lastUpdated"
 type GKMCache struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -118,7 +119,7 @@ func (cache GKMCache) GetImage() string {
 }
 
 func (cache GKMCache) GetStatus() *GKMCacheStatus {
-	return &cache.Status
+	return cache.Status.DeepCopy()
 }
 
 func (cache GKMCache) GetClientObject() client.Object {

--- a/api/v1alpha1/gkmcachenode_types.go
+++ b/api/v1alpha1/gkmcachenode_types.go
@@ -37,6 +37,7 @@ import (
 // +kubebuilder:printcolumn:name="Node-Not-In-Use",type=string,JSONPath=`.status.counts.nodeNotInUseCnt`
 // +kubebuilder:printcolumn:name="Node-Error",type=string,JSONPath=`.status.counts.nodeErrorCnt`
 // +kubebuilder:printcolumn:name="Pod-Running",type=string,JSONPath=`.status.counts.podRunningCnt`
+// +kubebuilder:printcolumn:name="Pod-Deleting",type=string,JSONPath=`.status.counts.podDeletingCnt`
 // +kubebuilder:printcolumn:name="Pod-Outdated",type=string,JSONPath=`.status.counts.podOutdatedCnt`
 type GKMCacheNode struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -79,7 +80,7 @@ func (cacheNode GKMCacheNode) GetLabels() map[string]string {
 }
 
 func (cacheNode GKMCacheNode) GetStatus() *GKMCacheNodeStatus {
-	return &cacheNode.Status
+	return cacheNode.Status.DeepCopy()
 }
 
 func (cacheNode GKMCacheNode) GetNodeName() string {

--- a/api/v1alpha1/shared_types.go
+++ b/api/v1alpha1/shared_types.go
@@ -49,6 +49,10 @@ type CacheCounts struct {
 	// volume mounted.
 	PodRunningCnt int `json:"podRunningCnt"`
 
+	// podDeletingCnt contains the total number of pods that the Kernel Cache is
+	// volume mounted but the GKMCache or ClusterGKMCache has been deleted.
+	PodDeletingCnt int `json:"podDeletingCnt"`
+
 	// podOutdatedCnt contains the total number of pods that the Kernel Cache is
 	// volume mounted, but a newer version of the extracted Kernel Cache has been
 	// extracted. This happens when a Kernel Cache is being used, but the
@@ -248,6 +252,16 @@ type PvcStatus struct {
 	// for the storage of the extract GPU Kernel Cache.
 	PvcName string `json:"pvcName,omitempty"`
 
+	// jobName contains the name of the Job that was created to perform the
+	// extraction GPU Kernel Cache.
+	JobName string `json:"jobName,omitempty"`
+
+	// pvcOwner is an indication of which process, Agent or Operator, manages the
+	// PVC used to store the extracted GPU Kernel Cache. Value of Agent indicates
+	// Agent manages the PVC, value of Operator indicates Operator manages the PVC.
+	// +kubebuilder:default:=Unknown
+	PvcOwner PvcOwner `json:"pvcOwner,omitempty"`
+
 	// conditions contains the summary state for the GPU Kernel Cache on the
 	// Kubernetes node referenced by status.nodeName.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -256,10 +270,6 @@ type PvcStatus struct {
 type GKMCacheNodeStatus struct {
 	// nodeName is the name of the Kubernetes Node this instance is created.
 	NodeName string `json:"nodeName"`
-
-	// resolvedDigest contains the digest of the image after it has been verified.
-	// This is a copy of the field in the GKMCache or ClusterGKMCache.
-	ResolvedDigest string `json:"resolvedDigest,omitempty"`
 
 	// counts contains statistics on the deployment of the GPU Kernel Cache for the
 	// Kubernetes node referenced in nodeName.
@@ -316,9 +326,17 @@ const (
 	// but a newer image digest exists.
 	GkmCondOutdated GkmConditionType = "Outdated"
 
+	// GkmCondDeleting indicates that the GKM Cache has been deleted but is
+	// being used by a Pod on the given node, so PVC not deleted yet.
+	GkmCondDeleting GkmConditionType = "Deleting"
+
 	// GkmCondError indicates that an error has occurred on the given
 	// node while attempting to apply the configuration described in the CRD.
 	GkmCondError GkmConditionType = "Error"
+
+	// GkmCondNoNamespace indicates that Namespace the workload will run in
+	// and PVC needs to be created in does not exist.
+	GkmCondNoNamespace GkmConditionType = "NoNamespace"
 
 	// GkmCondUnloadError indicates that the GKM Cache was marked
 	// for deletion, but removing GK Cache was unsuccessful on the
@@ -372,6 +390,14 @@ func (b GkmConditionType) Condition() metav1.Condition {
 			Reason:  "Outdated",
 			Message: "The Kernel Cache is in use by one or more pods but newer version exists",
 		}
+	case GkmCondDeleting:
+		condType := string(GkmCondDeleting)
+		cond = metav1.Condition{
+			Type:    condType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Deleting",
+			Message: "Cache instance has been deleted but PVC is still in use by one or more pods",
+		}
 	case GkmCondError:
 		condType := string(GkmCondError)
 		cond = metav1.Condition{
@@ -380,12 +406,20 @@ func (b GkmConditionType) Condition() metav1.Condition {
 			Reason:  "Error",
 			Message: "An error occurred trying to extract the Kernel Cache",
 		}
+	case GkmCondNoNamespace:
+		condType := string(GkmCondNoNamespace)
+		cond = metav1.Condition{
+			Type:    condType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "NoNamespace",
+			Message: "Workload Namespace does not exist",
+		}
 	case GkmCondUnloadError:
 		condType := string(GkmCondUnloadError)
 		cond = metav1.Condition{
 			Type:    condType,
 			Status:  metav1.ConditionTrue,
-			Reason:  "Unload Error",
+			Reason:  "UnloadError",
 			Message: "An error occurred trying to remove the extracted Kernel Cache",
 		}
 	}
@@ -409,7 +443,8 @@ func IsConditionDownloadSet(conditions []metav1.Condition) bool {
 	for _, condition := range conditions {
 		if condition.Type == string(GkmCondExtracted) ||
 			condition.Type == string(GkmCondRunning) ||
-			condition.Type == string(GkmCondOutdated) {
+			condition.Type == string(GkmCondOutdated) ||
+			condition.Type == string(GkmCondDeleting) {
 			return true
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -25,10 +26,12 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -160,6 +163,24 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Index Pods by spec.nodeName
+	ctx := context.Background()
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&corev1.Pod{},
+		"spec.nodeName",
+		func(obj client.Object) []string {
+			pod := obj.(*corev1.Pod)
+			if pod.Spec.NodeName == "" {
+				return nil
+			}
+			return []string{pod.Spec.NodeName}
+		},
+	); err != nil {
+		setupLog.Error(err, "Failed to register Pod field indexer")
 		os.Exit(1)
 	}
 

--- a/config/crd/bases/gkm.io_clustergkmcachenodes.yaml
+++ b/config/crd/bases/gkm.io_clustergkmcachenodes.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .status.counts.podRunningCnt
       name: Pod-Running
       type: string
+    - jsonPath: .status.counts.podDeletingCnt
+      name: Pod-Deleting
+      type: string
     - jsonPath: .status.counts.podOutdatedCnt
       name: Pod-Outdated
       type: string
@@ -177,6 +180,11 @@ spec:
                                 - type
                                 type: object
                               type: array
+                            jobName:
+                              description: |-
+                                jobName contains the name of the Job that was created to perform the
+                                extraction GPU Kernel Cache.
+                              type: string
                             pvName:
                               description: |-
                                 pvName contains the name of the Persistent Volume that was created for the
@@ -186,6 +194,17 @@ spec:
                               description: |-
                                 pvcName contains the name of the Persistent Volume Claim that was created
                                 for the storage of the extract GPU Kernel Cache.
+                              type: string
+                            pvcOwner:
+                              default: Unknown
+                              description: |-
+                                pvcOwner is an indication of which process, Agent or Operator, manages the
+                                PVC used to store the extracted GPU Kernel Cache. Value of Agent indicates
+                                Agent manages the PVC, value of Operator indicates Operator manages the PVC.
+                              enum:
+                              - Unknown
+                              - Agent
+                              - Operator
                               type: string
                           type: object
                         description: |-
@@ -238,6 +257,11 @@ spec:
                       has been extracted and that the Kernel Cache is not currently being used by
                       a pod on that node.
                     type: integer
+                  podDeletingCnt:
+                    description: |-
+                      podDeletingCnt contains the total number of pods that the Kernel Cache is
+                      volume mounted but the GKMCache or ClusterGKMCache has been deleted.
+                    type: integer
                   podOutdatedCnt:
                     description: |-
                       podOutdatedCnt contains the total number of pods that the Kernel Cache is
@@ -255,6 +279,7 @@ spec:
                 - nodeErrorCnt
                 - nodeInUseCnt
                 - nodeNotInUseCnt
+                - podDeletingCnt
                 - podOutdatedCnt
                 - podRunningCnt
                 type: object
@@ -283,11 +308,6 @@ spec:
               nodeName:
                 description: nodeName is the name of the Kubernetes Node this instance
                   is created.
-                type: string
-              resolvedDigest:
-                description: |-
-                  resolvedDigest contains the digest of the image after it has been verified.
-                  This is a copy of the field in the GKMCache or ClusterGKMCache.
                 type: string
             required:
             - counts

--- a/config/crd/bases/gkm.io_clustergkmcaches.yaml
+++ b/config/crd/bases/gkm.io_clustergkmcaches.yaml
@@ -36,6 +36,9 @@ spec:
     - jsonPath: .status.counts.podRunningCnt
       name: Pod-Running
       type: string
+    - jsonPath: .status.counts.podDeletingCnt
+      name: Pod-Deleting
+      type: string
     - jsonPath: .status.counts.podOutdatedCnt
       name: Pod-Outdated
       type: string
@@ -1258,6 +1261,11 @@ spec:
                       has been extracted and that the Kernel Cache is not currently being used by
                       a pod on that node.
                     type: integer
+                  podDeletingCnt:
+                    description: |-
+                      podDeletingCnt contains the total number of pods that the Kernel Cache is
+                      volume mounted but the GKMCache or ClusterGKMCache has been deleted.
+                    type: integer
                   podOutdatedCnt:
                     description: |-
                       podOutdatedCnt contains the total number of pods that the Kernel Cache is
@@ -1275,6 +1283,7 @@ spec:
                 - nodeErrorCnt
                 - nodeInUseCnt
                 - nodeNotInUseCnt
+                - podDeletingCnt
                 - podOutdatedCnt
                 - podRunningCnt
                 type: object
@@ -1358,6 +1367,11 @@ spec:
                         - type
                         type: object
                       type: array
+                    jobName:
+                      description: |-
+                        jobName contains the name of the Job that was created to perform the
+                        extraction GPU Kernel Cache.
+                      type: string
                     pvName:
                       description: |-
                         pvName contains the name of the Persistent Volume that was created for the
@@ -1367,6 +1381,17 @@ spec:
                       description: |-
                         pvcName contains the name of the Persistent Volume Claim that was created
                         for the storage of the extract GPU Kernel Cache.
+                      type: string
+                    pvcOwner:
+                      default: Unknown
+                      description: |-
+                        pvcOwner is an indication of which process, Agent or Operator, manages the
+                        PVC used to store the extracted GPU Kernel Cache. Value of Agent indicates
+                        Agent manages the PVC, value of Operator indicates Operator manages the PVC.
+                      enum:
+                      - Unknown
+                      - Agent
+                      - Operator
                       type: string
                   type: object
                 description: |-

--- a/config/crd/bases/gkm.io_gkmcachenodes.yaml
+++ b/config/crd/bases/gkm.io_gkmcachenodes.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .status.counts.podRunningCnt
       name: Pod-Running
       type: string
+    - jsonPath: .status.counts.podDeletingCnt
+      name: Pod-Deleting
+      type: string
     - jsonPath: .status.counts.podOutdatedCnt
       name: Pod-Outdated
       type: string
@@ -177,6 +180,11 @@ spec:
                                 - type
                                 type: object
                               type: array
+                            jobName:
+                              description: |-
+                                jobName contains the name of the Job that was created to perform the
+                                extraction GPU Kernel Cache.
+                              type: string
                             pvName:
                               description: |-
                                 pvName contains the name of the Persistent Volume that was created for the
@@ -186,6 +194,17 @@ spec:
                               description: |-
                                 pvcName contains the name of the Persistent Volume Claim that was created
                                 for the storage of the extract GPU Kernel Cache.
+                              type: string
+                            pvcOwner:
+                              default: Unknown
+                              description: |-
+                                pvcOwner is an indication of which process, Agent or Operator, manages the
+                                PVC used to store the extracted GPU Kernel Cache. Value of Agent indicates
+                                Agent manages the PVC, value of Operator indicates Operator manages the PVC.
+                              enum:
+                              - Unknown
+                              - Agent
+                              - Operator
                               type: string
                           type: object
                         description: |-
@@ -238,6 +257,11 @@ spec:
                       has been extracted and that the Kernel Cache is not currently being used by
                       a pod on that node.
                     type: integer
+                  podDeletingCnt:
+                    description: |-
+                      podDeletingCnt contains the total number of pods that the Kernel Cache is
+                      volume mounted but the GKMCache or ClusterGKMCache has been deleted.
+                    type: integer
                   podOutdatedCnt:
                     description: |-
                       podOutdatedCnt contains the total number of pods that the Kernel Cache is
@@ -255,6 +279,7 @@ spec:
                 - nodeErrorCnt
                 - nodeInUseCnt
                 - nodeNotInUseCnt
+                - podDeletingCnt
                 - podOutdatedCnt
                 - podRunningCnt
                 type: object
@@ -283,11 +308,6 @@ spec:
               nodeName:
                 description: nodeName is the name of the Kubernetes Node this instance
                   is created.
-                type: string
-              resolvedDigest:
-                description: |-
-                  resolvedDigest contains the digest of the image after it has been verified.
-                  This is a copy of the field in the GKMCache or ClusterGKMCache.
                 type: string
             required:
             - counts

--- a/config/crd/bases/gkm.io_gkmcaches.yaml
+++ b/config/crd/bases/gkm.io_gkmcaches.yaml
@@ -39,6 +39,9 @@ spec:
     - jsonPath: .status.counts.podOutdatedCnt
       name: Pod-Outdated
       type: string
+    - jsonPath: .status.counts.podDeletingCnt
+      name: Pod-Deleting
+      type: string
     - jsonPath: .status.lastUpdated
       name: Last=Updated
       priority: 1
@@ -1256,6 +1259,11 @@ spec:
                       has been extracted and that the Kernel Cache is not currently being used by
                       a pod on that node.
                     type: integer
+                  podDeletingCnt:
+                    description: |-
+                      podDeletingCnt contains the total number of pods that the Kernel Cache is
+                      volume mounted but the GKMCache or ClusterGKMCache has been deleted.
+                    type: integer
                   podOutdatedCnt:
                     description: |-
                       podOutdatedCnt contains the total number of pods that the Kernel Cache is
@@ -1273,6 +1281,7 @@ spec:
                 - nodeErrorCnt
                 - nodeInUseCnt
                 - nodeNotInUseCnt
+                - podDeletingCnt
                 - podOutdatedCnt
                 - podRunningCnt
                 type: object
@@ -1356,6 +1365,11 @@ spec:
                         - type
                         type: object
                       type: array
+                    jobName:
+                      description: |-
+                        jobName contains the name of the Job that was created to perform the
+                        extraction GPU Kernel Cache.
+                      type: string
                     pvName:
                       description: |-
                         pvName contains the name of the Persistent Volume that was created for the
@@ -1365,6 +1379,17 @@ spec:
                       description: |-
                         pvcName contains the name of the Persistent Volume Claim that was created
                         for the storage of the extract GPU Kernel Cache.
+                      type: string
+                    pvcOwner:
+                      default: Unknown
+                      description: |-
+                        pvcOwner is an indication of which process, Agent or Operator, manages the
+                        PVC used to store the extracted GPU Kernel Cache. Value of Agent indicates
+                        Agent manages the PVC, value of Operator indicates Operator manages the PVC.
+                      enum:
+                      - Unknown
+                      - Agent
+                      - Operator
                       type: string
                   type: object
                 description: |-

--- a/config/rbac/gkm-operator/role.yaml
+++ b/config/rbac/gkm-operator/role.yaml
@@ -16,6 +16,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   - persistentvolumes
   verbs:
@@ -25,6 +33,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
   - watch
 - apiGroups:
   - apps

--- a/examples/vllm/k8s/20-llama-cache.yaml
+++ b/examples/vllm/k8s/20-llama-cache.yaml
@@ -3,6 +3,10 @@ kind: GKMCache
 metadata:
   name: llama-3-1-8b-instruct-rocm
   namespace: gkm-test-ns-scoped
-  annotations:
+  labels:
+    gkm.io/signature-format: cosign-v2
 spec:
-  image: quay.io/gkm/cache-examples:llama-3.1-8B-instruct-rocm
+  image: quay.io/gkm/cache-examples:llama-3.1-8B-instruct-rocm-v2
+  accessModes:
+    - ReadWriteOnce
+    - ReadOnlyMany

--- a/examples/vllm/k8s/30-llama-rocm-cached-pod.yaml
+++ b/examples/vllm/k8s/30-llama-rocm-cached-pod.yaml
@@ -52,8 +52,5 @@ spec:
     - name: model-hf-volume
       emptyDir: {}
     - name: model-cache-volume
-      csi:
-        driver: csi.gkm.io
-        volumeAttributes:
-          csi.gkm.io/GKMCache: llama-3-1-8b-instruct-rocm
-          csi.gkm.io/namespace: gkm-test-ns-scoped
+      persistentVolumeClaim:
+        claimName: llama-3-1-8b-instruct-rocm

--- a/internal/controller/gkm-agent/cluster_gkmcache_controller.go
+++ b/internal/controller/gkm-agent/cluster_gkmcache_controller.go
@@ -21,11 +21,13 @@ package gkmAgent
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,8 +35,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gkmv1alpha1 "github.com/redhat-et/GKM/api/v1alpha1"
+	"github.com/redhat-et/GKM/pkg/common"
 	"github.com/redhat-et/GKM/pkg/utils"
 )
 
@@ -50,7 +54,12 @@ import (
 
 // ClusterGKMCacheAgentReconciler reconciles a ClusterGKMCache object
 type ClusterGKMCacheAgentReconciler struct {
-	ReconcilerCommonAgent[gkmv1alpha1.ClusterGKMCache, gkmv1alpha1.ClusterGKMCacheList, gkmv1alpha1.ClusterGKMCacheNode]
+	ReconcilerCommonAgent[
+		gkmv1alpha1.ClusterGKMCache,
+		gkmv1alpha1.ClusterGKMCacheList,
+		gkmv1alpha1.ClusterGKMCacheNode,
+		gkmv1alpha1.ClusterGKMCacheNodeList,
+	]
 }
 
 // ClusterGKMCacheAgentReconciler reconciles/reads each ClusterGKMCache object (read-only) and creates and
@@ -65,12 +74,7 @@ func (r *ClusterGKMCacheAgentReconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterGKMCacheAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gkmv1alpha1.ClusterGKMCache{},
-			builder.WithPredicates(predicate.And(
-				predicate.GenerationChangedPredicate{},
-				predicate.ResourceVersionChangedPredicate{},
-			)),
-		).
+		For(&gkmv1alpha1.ClusterGKMCache{}).
 		// Trigger reconciliation if the ClusterGKMCacheNode for this node is modified.
 		// Own() doesn't work because the ClusterGKMCacheNode is per Namespace and the
 		// ClusterGKMCache is not an ownerRef, because there may be multiple ClusterGKMCache
@@ -79,6 +83,11 @@ func (r *ClusterGKMCacheAgentReconciler) SetupWithManager(mgr ctrl.Manager) erro
 			&gkmv1alpha1.ClusterGKMCacheNode{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates((ClusterGkmCacheNodePredicate(r.NodeName))),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueClusterGKMCacheNode),
+			builder.WithPredicates(common.PodPredicate(r.NodeName)),
 		).
 		Complete(r)
 }
@@ -101,10 +110,27 @@ func ClusterGkmCacheNodePredicate(nodeName string) predicate.Funcs {
 	}
 }
 
+func (r *ClusterGKMCacheAgentReconciler) enqueueClusterGKMCacheNode(ctx context.Context, obj client.Object) []reconcile.Request {
+	crList := &gkmv1alpha1.ClusterGKMCacheNodeList{}
+	if err := r.List(ctx, crList); err != nil || len(crList.Items) == 0 {
+		return nil
+	}
+
+	cr := crList.Items[0]
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name: cr.Name,
+			},
+		},
+	}
+}
+
 // GetCacheList gets the list of ClusterGKMCache objects from KubeAPI Server.
 func (r *ClusterGKMCacheAgentReconciler) getCacheList(
 	ctx context.Context,
-	opts []client.ListOption,
+	opts ...client.ListOption,
 ) (*gkmv1alpha1.ClusterGKMCacheList, error) {
 	// Get the list of existing ClusterGKMCache objects
 	cacheList := &gkmv1alpha1.ClusterGKMCacheList{}
@@ -114,6 +140,21 @@ func (r *ClusterGKMCacheAgentReconciler) getCacheList(
 	}
 
 	return cacheList, nil
+}
+
+// GetCacheNodeList gets the list of ClusterGKMCacheNode objects from KubeAPI Server.
+func (r *ClusterGKMCacheAgentReconciler) getCacheNodeList(
+	ctx context.Context,
+	opts ...client.ListOption,
+) (*gkmv1alpha1.ClusterGKMCacheNodeList, error) {
+	// Get the list of existing ClusterGKMCacheNode objects
+	cacheNodeList := &gkmv1alpha1.ClusterGKMCacheNodeList{}
+	if err := r.List(ctx, cacheNodeList, opts...); err != nil {
+		r.Logger.Error(err, "failed to list", "Object", r.CrdCacheStr)
+		return nil, err
+	}
+
+	return cacheNodeList, nil
 }
 
 // getCacheNode gets the ClusterGKMCacheNode object from KubeAPI Server for the current
@@ -192,28 +233,53 @@ func (r *ClusterGKMCacheAgentReconciler) cacheNodeUpdateStatus(
 	gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode,
 	nodeStatus *gkmv1alpha1.GKMCacheNodeStatus,
 	reason string,
-) error {
-	gkmCacheNode.Status = *nodeStatus.DeepCopy()
+) (bool, error) {
+	changed := true
 
-	r.Logger.Info("Calling KubeAPI to Update ClusterGKMCacheNode Status",
-		"reason", reason,
-		"Namespace", gkmCacheNode.Namespace,
-		"CacheNodeName", gkmCacheNode.Name,
-	)
-	if err := r.Status().Update(ctx, gkmCacheNode); err != nil {
-		if strings.Contains(err.Error(), "object has been modified") {
-			r.Logger.Info("failed to update ClusterGKMCacheNode Status - outdated",
-				"reason", reason,
-				"Namespace", gkmCacheNode.Namespace,
-				"CacheNodeName", gkmCacheNode.Name,
-				"Error", err,
-			)
-		} else {
-			r.Logger.Error(err, "failed to update ClusterGKMCacheNode Status",
-				"reason", reason,
-				"Namespace", gkmCacheNode.Namespace,
-				"CacheNodeName", gkmCacheNode.Name)
+	if !reflect.DeepEqual(gkmCacheNode.GetStatus().DeepCopy(), nodeStatus) {
+		gkmCacheNode.Status = *nodeStatus.DeepCopy()
+
+		r.Logger.Info("Calling KubeAPI to Update ClusterGKMCacheNode Status",
+			"reason", reason,
+			"Namespace", gkmCacheNode.Namespace,
+			"CacheNodeName", gkmCacheNode.Name,
+		)
+		if err := r.Status().Update(ctx, gkmCacheNode); err != nil {
+			if strings.Contains(err.Error(), "object has been modified") {
+				r.Logger.Info("failed to update ClusterGKMCacheNode Status - outdated",
+					"reason", reason,
+					"Namespace", gkmCacheNode.Namespace,
+					"CacheNodeName", gkmCacheNode.Name,
+					"Error", err,
+				)
+			} else {
+				r.Logger.Error(err, "failed to update ClusterGKMCacheNode Status",
+					"reason", reason,
+					"Namespace", gkmCacheNode.Namespace,
+					"CacheNodeName", gkmCacheNode.Name)
+			}
+			return changed, err
 		}
+	} else {
+		changed = false
+		r.Logger.Info("cacheNodeUpdateStatus() called but nothing changed",
+			"reason", reason,
+			"Namespace", gkmCacheNode.Namespace,
+			"CacheNodeName", gkmCacheNode.Name,
+		)
+	}
+
+	return changed, nil
+}
+
+// deleteCacheNode deletes the ClusterGKMCacheNode Object for this Node.
+func (r *ClusterGKMCacheAgentReconciler) deleteCacheNode(ctx context.Context, gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode) error {
+	r.Logger.Info("Delete ClusterGKMCacheNode object",
+		"Namespace", gkmCacheNode.Namespace, "CacheNodeName", gkmCacheNode.Name)
+
+	if err := r.Delete(ctx, gkmCacheNode); err != nil {
+		r.Logger.Error(err, "failed to delete GKMCacheNode object",
+			"Namespace", gkmCacheNode.Namespace, "CacheNodeName", gkmCacheNode.Name)
 		return err
 	}
 
@@ -237,7 +303,7 @@ func (r *ClusterGKMCacheAgentReconciler) cacheNodeAddFinalizer(
 	gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode,
 	cacheName string,
 ) (bool, error) {
-	if changed := controllerutil.AddFinalizer(gkmCacheNode, r.getCacheNodeFinalizer(cacheName)); changed {
+	if changed := controllerutil.AddFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)); changed {
 		r.Logger.Info("Calling KubeAPI to add ClusterGKMCache Finalizer to ClusterGKMCacheNode",
 			"Namespace", gkmCacheNode.Namespace,
 			"Name", cacheName,
@@ -256,17 +322,26 @@ func (r *ClusterGKMCacheAgentReconciler) cacheNodeAddFinalizer(
 	return false, nil
 }
 
-// getCacheNodeFinalizer returns the finalizer that is added to the ClusterGKMCacheNode object.
-func (r *ClusterGKMCacheAgentReconciler) getCacheNodeFinalizer(name string) string {
+// getCacheNodeFinalizerName returns the finalizer that is added to the ClusterGKMCacheNode object.
+func (r *ClusterGKMCacheAgentReconciler) getCacheNodeFinalizerName(name string) string {
 	return utils.GkmCacheNodeFinalizerPrefix + name + utils.GkmCacheNodeFinalizerSubstring
+}
+
+// hasCacheNodeFinalizer determines if ClusterGKMCacheNode object has a finalizer added.
+func (r *ClusterGKMCacheAgentReconciler) hasCacheNodeFinalizer(cacheName string, gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode) bool {
+	if controllerutil.ContainsFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)) {
+		return true
+	} else {
+		return false
+	}
 }
 
 func (r *ClusterGKMCacheAgentReconciler) cacheNodeRemoveFinalizer(
 	ctx context.Context,
-	gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode,
 	cacheName string,
+	gkmCacheNode *gkmv1alpha1.ClusterGKMCacheNode,
 ) (bool, error) {
-	if changed := controllerutil.RemoveFinalizer(gkmCacheNode, r.getCacheNodeFinalizer(cacheName)); changed {
+	if changed := controllerutil.RemoveFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)); changed {
 		r.Logger.Info("Calling KubeAPI to delete ClusterGKMCache Finalizer from ClusterGKMCacheNode",
 			"Namespace", gkmCacheNode.Namespace,
 			"Name", cacheName,

--- a/internal/controller/gkm-agent/common.go
+++ b/internal/controller/gkm-agent/common.go
@@ -88,7 +88,15 @@ type GKMNodeInstance interface {
 	GetClientObject() client.Object
 }
 
-type ReconcilerCommonAgent[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance] struct {
+// GKMNodeInstanceList is a generic interface that is a list of type N, which is a list
+// of GKMNodeInstance, which is either GKMCacheNode or ClusterGKMCacheNode.
+type GKMNodeInstanceList[N any] interface {
+	// gkmv1alpha1.GKMCacheNodeList | gkmv1alpha1.ClusterGKMCacheNodeList
+	GetItems() []N
+	GetItemsLen() int
+}
+
+type ReconcilerCommonAgent[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance, NL GKMNodeInstanceList[N]] struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	Logger          logr.Logger
@@ -104,7 +112,7 @@ type ReconcilerCommonAgent[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstan
 // AgentReconciler is an interface that defines the methods needed to reconcile
 // a GKMCache or ClusterGKMCache object. The only difference between the two
 // object is that a Cluster object does not have a Namespace (which is just "").
-type AgentReconciler[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance] interface {
+type AgentReconciler[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance, NL GKMNodeInstanceList[N]] interface {
 	// Reconcile is the main entry point to the reconciler. It will be called by
 	// the controller runtime when something happens that the reconciler is
 	// interested in. When Reconcile() is invoked, it initializes some state in
@@ -117,18 +125,24 @@ type AgentReconciler[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance] in
 	SetupWithManager(mgr ctrl.Manager) error
 
 	// GetCacheList calls the Kubernetes API server to retrieve a list of GKMCache or ClusterGKMCache objects.
-	getCacheList(ctx context.Context, opts []client.ListOption) (*CL, error)
+	getCacheList(ctx context.Context, opts ...client.ListOption) (*CL, error)
+
+	// GetCacheNodeList calls the Kubernetes API server to retrieve a list of GKMCacheNode or ClusterGKMCacheNode objects.
+	getCacheNodeList(ctx context.Context, opts ...client.ListOption) (*NL, error)
 
 	getCacheNode(ctx context.Context, cacheNamespace string, cacheName string) (*N, error)
 	createCacheNode(ctx context.Context, cacheNamespace, cacheName string) error
 
-	cacheNodeUpdateStatus(ctx context.Context, gkmCacheNode *N, status *gkmv1alpha1.GKMCacheNodeStatus, reason string) error
+	cacheNodeUpdateStatus(ctx context.Context, gkmCacheNode *N, status *gkmv1alpha1.GKMCacheNodeStatus, reason string) (bool, error)
+
+	deleteCacheNode(ctx context.Context, gkmCacheNode *N) error
 
 	isBeingDeleted(gkmCache *C) bool
 	validExtractedCache(cacheNamespace string) bool
 
 	cacheNodeAddFinalizer(ctx context.Context, gkmCacheNode *N, cacheName string) (bool, error)
-	cacheNodeRemoveFinalizer(ctx context.Context, gkmCacheNode *N, cacheName string) (bool, error)
+	hasCacheNodeFinalizer(cacheName string, gkmCacheNode *N) bool
+	cacheNodeRemoveFinalizer(ctx context.Context, cacheName string, gkmCacheNode *N) (bool, error)
 
 	cacheNodeRecordEvent(
 		gkmCacheNode *N,
@@ -147,9 +161,9 @@ type AgentReconciler[C GKMInstance, CL GKMInstanceList[C], N GKMNodeInstance] in
 // and makes sure the intended state is applied. The Agent owns GKMCacheNode and
 // ClusterGKMCacheNode Objects, and calls KubeAPI Server to make sure they reflect
 // the current state of the GKMCache and ClusterGKMCache Objects on a given node.
-func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) reconcileCommonAgent(
 	ctx context.Context,
-	reconciler AgentReconciler[C, CL, N],
+	reconciler AgentReconciler[C, CL, N, NL],
 ) (ctrl.Result, error) {
 	errorHit := false
 	stillInUse := false
@@ -159,8 +173,10 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 
 	r.Logger.V(1).Info("Start reconcileCommonAgent()")
 
+	inUseGkmCacheNodeList := make(map[string]bool)
+
 	// Get the list of existing GKMCache or ClusterGKMCache objects from KubeAPI Server.
-	gkmCacheList, err := reconciler.getCacheList(ctx, []client.ListOption{})
+	gkmCacheList, err := reconciler.getCacheList(ctx)
 	if err != nil {
 		return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentFailure},
 			fmt.Errorf("failed getting list of %s for full reconcile: %v",
@@ -171,7 +187,6 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 	if (*gkmCacheList).GetItemsLen() == 0 {
 		// KubeAPI doesn't have any GKMCache instances
 		r.Logger.Info("No GKMCache entries found")
-		return ctrl.Result{Requeue: false}, nil
 	} else {
 		// There are GKMCache instances created, so loop through each and reconcile each.
 		for _, gkmCache := range (*gkmCacheList).GetItems() {
@@ -181,6 +196,8 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 				"Name", gkmCache.GetName(),
 				"StorageClass", gkmCache.GetStorageClassName(),
 				"PvcOwner", gkmCache.GetPvcOwner())
+
+			cacheDeleting := reconciler.isBeingDeleted(&gkmCache)
 
 			// Call KubeAPI to Retrieve GKMCacheNode for this GKMCache
 			gkmCacheNode, err := reconciler.getCacheNode(ctx, gkmCache.GetNamespace(), gkmCache.GetName())
@@ -196,7 +213,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 			}
 
 			if gkmCacheNode == nil {
-				if reconciler.isBeingDeleted(&gkmCache) {
+				if cacheDeleting {
 					// If the GKMCacheNode doesn't exist and the GKMCache is being deleted,
 					// nothing to do. Just continue with the next GKMCache.
 					r.Logger.Info("Node object doesn't exist and Cache is being deleted",
@@ -213,263 +230,70 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 				} else {
 					// Creation of GKMCacheNode Object for this Namespace was successful.
 					// Return and Reconcile will be retriggered with the GKMCacheNode Object.
+					r.Logger.V(1).Info("Return after CacheNode Create")
 					return ctrl.Result{Requeue: false}, nil
 				}
 			}
+
+			inUseGkmCacheNodeList[(*gkmCacheNode).GetName()] = cacheDeleting
 
 			// GKMCacheNode and ClusterGKMCacheNode takes two steps to complete. The createCacheNode()
 			// call creates the Object, but r.currCacheNode.Status is not allowed to be updated in the
 			// KubeAPI Create call. So if the NodeName is not set, add the initial r.currCacheNode.Status
 			// data, which includes the NodeName and list of detected GPUs.
 			if (*gkmCacheNode).GetNodeName() != r.NodeName {
+				if cacheDeleting {
+					// If the GKMCacheNode hasn't been initialized and the GKMCache is being deleted,
+					// nothing to do. Just continue with the next GKMCache.
+					r.Logger.Info("Node hasn't been initialized and Cache is being deleted",
+						"Object", r.CrdCacheNodeStr,
+						"Namespace", gkmCache.GetNamespace(),
+						"Name", gkmCache.GetNamespace())
+					continue
+				}
+
+				// Make sure there is a GKMCache Finalizer added to the GKMCacheNode
+				if cacheNodeUpdated, err := r.addCacheFinalizerToCacheNode(ctx, reconciler, &gkmCache, gkmCacheNode); err != nil {
+					errorHit = true
+					continue
+				} else if cacheNodeUpdated {
+					r.Logger.Info("Finalizer added")
+					// GKMCacheNode Object was updated successfully.
+					// Return and Reconcile will be retriggered with the GKMCacheNode Object.
+					r.Logger.V(1).Info("Return after Finalizer Added")
+					return ctrl.Result{Requeue: false}, nil
+					//return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
+				}
+
 				// Add initial Status data to GKMCacheNode or ClusterGKMCacheNode object.
-				if err = r.addGpuToCacheNode(ctx, reconciler, gkmCacheNode); err != nil {
+				nodeStatus := gkmv1alpha1.GKMCacheNodeStatus{}
+				if err := r.addGpuToCacheNode(ctx, reconciler, &nodeStatus); err != nil {
 					errorHit = true
 					continue
 				} else {
-					// Creation of GKMCacheNode Object for this Namespace was successful.
-					// Return and Reconcile will be retriggered with the GKMCacheNode Object.
-					//return ctrl.Result{Requeue: false}, nil
-					return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
-				}
-			}
-
-			// Save a copy of GKMCacheNode. Use to determine if anything changes in processing.
-			//origCacheNode := r.currCacheNode.DeepCopy()
-
-			// See if Digest has been set (Webhook validated and image is allowed to be used).
-			annotations := gkmCache.GetAnnotations()
-			if resolvedDigest, digestFound := annotations[utils.GKMCacheAnnotationResolvedDigest]; digestFound {
-				capacity, capFound := annotations[utils.GKMCacheAnnotationCacheSizeBytes]
-				if !capFound {
-					capacity = "1Gi"
-					r.Logger.Info("Capacity NOT Found, setting to 1GB")
-				}
-
-				r.Logger.V(1).Info("Digest and Capacity Found",
-					"Object", r.CrdCacheStr,
-					"Namespace", gkmCache.GetNamespace(),
-					"Name", gkmCache.GetName(),
-					"Digest", resolvedDigest,
-					"Capacity", capacity,
-				)
-
-				// Before extracting and doing work on a given Cache, make sure it is not being deleted.
-				if reconciler.isBeingDeleted(&gkmCache) {
-					inUse, cacheNodeUpdated, err := r.removeCacheFromCacheNode(
-						ctx, reconciler, gkmCacheNode, gkmCache.GetNamespace(), gkmCache.GetName(), resolvedDigest)
+					changed, err := reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, &nodeStatus, "Update GPU list")
 					if err != nil {
 						errorHit = true
 						continue
-					} else if inUse {
-						// Remember that one on the Cache is still in use, so requeue can be set properly on return.
-						stillInUse = true
-					} else if cacheNodeUpdated {
-						// KubeAPI was called to update the GKMCacheNode Object. Return and Reconcile
-						// will be retriggered with the GKMCacheNode Object update.
-						//return ctrl.Result{Requeue: false}, nil
-						return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
-					}
+					} else {
+						reconciler.cacheNodeRecordEvent(gkmCacheNode, gkmv1alpha1.GkmCacheNodeEventReasonCreated, "", "", "", 0)
 
-					// Update counts for this GKMCache (or ClusterGKMCache).
-					// BILLY: Make sure counts get updated for deleting Caches
-					// nodeCnts[gkmCache.GetName()] = cnts
-
-					// No work done, so process next Cache instance
-					continue
-				}
-
-				// Check the Condition for this Cache and Digest to see if this Digest has
-				// been extracted.
-				nodeStatus := (*gkmCacheNode).GetStatus()
-				if nodeStatus != nil {
-					updated := false
-					updateReason := ""
-
-					cnts := gkmv1alpha1.CacheCounts{}
-					cnts.NodeCnt = 1
-
-					// Squirrel away the resolvedDigest in the CacheNode for the Webhook to access quickly
-					nodeStatus.ResolvedDigest = resolvedDigest
-
-					cacheStatus, cacheStatusExisted := nodeStatus.CacheStatuses[gkmCache.GetName()][resolvedDigest]
-					if !cacheStatusExisted {
-						r.Logger.Info("CacheStatus does NOT exist, add Finalizer now")
-						// This GKMCache/Digest has not been processed yet.
-						// Step 1: Make sure there is a GKMCache Finalizer added to the GKMCacheNode
-						if cacheNodeUpdated, err := r.addCacheFinalizerToCacheNode(ctx, reconciler, &gkmCache, gkmCacheNode); err != nil {
-							errorHit = true
-							continue
-						} else if cacheNodeUpdated {
-							// GKMCacheNode Object was updated successfully.
-							// Return and Reconcile will be retriggered with the GKMCacheNode Object.
-							//return ctrl.Result{Requeue: false}, nil
-							return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
-						}
-					}
-
-					// If the GKMCache or ClusterGKMCache Owner has not been set, just skip over this
-					// Cache and reevaluate on next pass.
-					if gkmCache.GetPvcOwner() == gkmv1alpha1.PvcOwnerUnknown ||
-						gkmCache.GetPvcOwner() == "" {
-						stillInUse = true
-						continue
-					}
-					// If the PVC AccessMode is ReadOnlyMany, then only one PVC per Namespace needs to be
-					// created and the storage backend will handle propagating the extracted cache to each
-					// node. Since there is only one, the Operator handles the creation. The Agent tracks
-					// the state. PVC AccessMode is ReadWriteOnce, the storage backend can not handle
-					// propagating the extracted cache so the Agent does it by creating a PVC per Namespace
-					// per Node. For GKMCache, it is the Namespace it is created in. For ClusterGKMCache,
-					// it is the Namespace of the workload (pod mounting the PVC), which must be provided
-					// in the ClusterGKMCache by the user.
-
-					// If the initial read of the Status failed and the initialization work was completed
-					// (Finalizer was added) and the PVC Owner is set, now the Agent can continue processing
-					// this GKMCache or ClusterGKMCache. Go ahead and allocate the memory need.
-					if !cacheStatusExisted {
-						r.Logger.Info("CacheStatus does NOT exist, and Finalizer was already added, so initialize CacheStatus now.")
-
-						// Build up GKMCacheNode.Status
-						if len(nodeStatus.CacheStatuses) == 0 {
-							r.Logger.Info("Allocating GKMCacheNode.Status.CacheStatuses",
-								"Namespace", gkmCache.GetNamespace(),
-								"Name", gkmCache.GetName(),
-								"CacheNodeName", (*gkmCacheNode).GetName(),
-								"Digest", resolvedDigest)
-							nodeStatus.CacheStatuses = make(map[string]map[string]gkmv1alpha1.CacheStatus)
-						}
-
-						nodeStatus.CacheStatuses[gkmCache.GetName()] = make(map[string]gkmv1alpha1.CacheStatus)
-
-						// Build up the first GKMCacheNode.Status.CacheStatuses[name][resolvedDigest]
-						cacheStatus = gkmv1alpha1.CacheStatus{}
-
-						// Make sure KubeAPI is called to write this GKMCacheNode or ClusterGKMCacheNode
-						// below once some work is done.
-						updated = true
-						updateReason = "Cache Allocation"
-					}
-
-					// Loop through the list of Namespaces. For GKMCache, it's just the namespace
-					// GKMCache is created in. For ClusterGKMCache, it's the Workload Namespace list
-					// that was provided in ClusterGKMCache.
-					namespaceList := gkmCache.GetWorkloadNamespaces()
-					if len(namespaceList) == 0 {
-						if gkmCache.GetNamespace() == "" {
-							r.Logger.Info("No namespaces in ClusterGKMCache Spec.WorkloadNamespaces, so no PVCs created",
-								"Namespace", gkmCache.GetNamespace(),
-								"Name", gkmCache.GetName(),
-							)
-						}
-					}
-					for _, pvcNamespace := range namespaceList {
-						// Get the PVC Status, which is the Per Namespace PV and PVC information.
-						if cacheStatus.PvcStatus == nil {
-							cacheStatus.PvcStatus = make(map[string]gkmv1alpha1.PvcStatus)
-							updated = true
-							updateReason = "PvcStatus Allocation"
-						}
-
-						pvcStatus, pvcStatusExisted := cacheStatus.PvcStatus[pvcNamespace]
-						if !pvcStatusExisted {
-							pvcStatus = gkmv1alpha1.PvcStatus{}
-							gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondPending.Condition())
-							updated = true
-							updateReason = "PvcStatus Initialization"
-						}
-
-						// Manage PV and PVC
-						// If updated is already true, still manage PV and PVCs, because up to this
-						// point, it's just been initialization and allocation of structures, no
-						// actual work on kube objects.
-						if pvcUpdated, pvcReason, err := r.managePVandPVC(
-							ctx,
-							reconciler,
-							&gkmCache,
-							gkmCacheNode,
-							&pvcStatus,
-							pvcNamespace,
-							resolvedDigest,
-							capacity,
-						); err != nil {
-							errorHit = true
-							continue
-						} else if pvcUpdated {
-							updated = true
-							updateReason = pvcReason
-						}
-
-						if !updated {
-							// Launch Job to Extract Cache
-							jobUpdated, pending, jobUpdateReason, err := r.manageJob(
-								ctx,
-								&gkmCache,
-								gkmCacheNode,
-								&cacheStatus,
-								&pvcStatus,
-								pvcNamespace,
-								resolvedDigest,
-							)
-							if err != nil {
-								errorHit = true
-								continue
-							}
-							if jobUpdated {
-								updated = true
-								updateReason = jobUpdateReason
-							}
-							if pending {
-								stillInUse = true
-							}
-						}
-
-						if !updated {
-							// Update counts for this Namespace.
-							updated, updateReason = r.addCounts(ctx, &cnts, pvcNamespace, &pvcStatus)
-						}
-
-						if updated {
-							// Update the Cache Status copy of the PVC Status before writing the data.
-							cacheStatus.PvcStatus[pvcNamespace] = pvcStatus
-							break
-						}
-					} // For each Namespace
-
-					// Update with the collected counts
-					nodeStatus.Counts = cnts
-					if !updated {
-						if !reflect.DeepEqual((*gkmCacheNode).GetStatus().DeepCopy(), nodeStatus) {
-							updated = true
-							updateReason = "Update Counts"
-						}
-					}
-
-					if updated {
-						// Update the Node Status copy of the Cache Status before writing the data.
-						cacheStatus.LastUpdated = metav1.Now()
-						nodeStatus.CacheStatuses[gkmCache.GetName()][resolvedDigest] = cacheStatus
-
-						err = reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, nodeStatus, updateReason)
-						if err != nil {
-							errorHit = true
-							continue
+						// Update to GKMCacheNode Object for this Namespace was successful.
+						// Return and Reconcile will be retriggered with the GKMCacheNode Object.
+						r.Logger.V(1).Info("Return after NodeStatus Write", "Reason", "Update GPU list", "changed", changed)
+						if changed {
+							return ctrl.Result{Requeue: false}, nil
 						} else {
-							// Update to GKMCacheNode Object for this Namespace was successful.
-							// Return and Reconcile will be retriggered with the GKMCacheNode Object.
-							//return ctrl.Result{Requeue: false}, nil
 							return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
 						}
 					}
-					nodeCnts[gkmCache.GetName()] = cnts
-				} else {
-					r.Logger.Info("Unable to retrieve Status for CacheNode, but Status should exist already",
-						"Namespace", gkmCache.GetNamespace(),
-						"Name", gkmCache.GetName(),
-						"Digest", resolvedDigest)
-					continue
 				}
-			} else {
+			}
+
+			// See if Digest has been set (Webhook validated and image is allowed to be used).
+			annotations := gkmCache.GetAnnotations()
+			resolvedDigest, digestFound := annotations[utils.GKMCacheAnnotationResolvedDigest]
+			if !digestFound {
 				// Webhook has not resolved image URL to a digest, so either Cosign failed
 				// or the image is invalid. This should never get here because Webhook should
 				// not let GKMCache get created without a valid image.
@@ -479,33 +303,362 @@ func (r *ReconcilerCommonAgent[C, CL, N]) reconcileCommonAgent(
 					"Name", gkmCache.GetName())
 
 				// ToDo: Update GKMCacheNode With Failure
+				continue
 			}
-		}
+
+			capacity, capacityFound := annotations[utils.GKMCacheAnnotationCacheSizeBytes]
+			if !capacityFound {
+				capacity = "1Gi"
+				r.Logger.Info("Capacity NOT Found, setting to 1GB")
+			}
+
+			r.Logger.V(1).Info("Digest and Capacity Found",
+				"Object", r.CrdCacheStr,
+				"Namespace", gkmCache.GetNamespace(),
+				"Name", gkmCache.GetName(),
+				"Digest", resolvedDigest,
+				"Capacity", capacity,
+			)
+
+			// Check the Condition for this Cache and Digest to see if this Digest has
+			// been extracted.
+			nodeStatus := (*gkmCacheNode).GetStatus()
+			if nodeStatus != nil {
+				updated := false
+				updateReason := ""
+				cacheInUse := false
+
+				cnts := gkmv1alpha1.CacheCounts{}
+				cnts.NodeCnt = 1
+
+				// Make sure the GKMCache or ClusterGKMCache Owner has been set, otherwise skip over this
+				// Cache and reevaluate on next pass.
+				if gkmCache.GetPvcOwner() != gkmv1alpha1.PvcOwnerUnknown && gkmCache.GetPvcOwner() != "" {
+					// If the PVC AccessMode is ReadOnlyMany, then only one PVC per Namespace needs to be
+					// created and the storage backend will handle propagating the extracted cache to each
+					// node. Since there is only one, the Operator handles the creation. The Agent tracks
+					// the state. IF PVC AccessMode is ReadWriteOnce, the storage backend can not handle
+					// propagating the extracted cache so the Agent does it by creating a PVC per Namespace
+					// per Node. For GKMCache, it is the Namespace it is created in. For ClusterGKMCache,
+					// it is the Namespace of the workload (pod mounting the PVC), which must be provided
+					// in the ClusterGKMCache by the user.
+
+					cacheStatus, cacheStatusExisted := nodeStatus.CacheStatuses[gkmCache.GetName()][resolvedDigest]
+
+					if cacheDeleting && !cacheStatusExisted {
+						r.Logger.Info("Cache Status doesn't exist and Cache being deleted",
+							"Namespace", gkmCache.GetNamespace(),
+							"Name", gkmCache.GetName(),
+							"CacheNodeName", (*gkmCacheNode).GetName(),
+							"Digest", resolvedDigest)
+					} else {
+						// If the initial read of the Status failed and the initialization work was completed
+						// (Finalizer was added) and the PVC Owner is set, now the Agent can continue processing
+						// this GKMCache or ClusterGKMCache. Go ahead and allocate the memory need.
+						if !cacheStatusExisted {
+							r.Logger.Info("CacheStatus does NOT exist, and Finalizer was already added, so initialize CacheStatus now.")
+
+							// Build up GKMCacheNode.Status
+							if len(nodeStatus.CacheStatuses) == 0 {
+								r.Logger.Info("Allocating GKMCacheNode.Status.CacheStatuses",
+									"Namespace", gkmCache.GetNamespace(),
+									"Name", gkmCache.GetName(),
+									"CacheNodeName", (*gkmCacheNode).GetName(),
+									"Digest", resolvedDigest)
+								nodeStatus.CacheStatuses = make(map[string]map[string]gkmv1alpha1.CacheStatus)
+							}
+
+							nodeStatus.CacheStatuses[gkmCache.GetName()] = make(map[string]gkmv1alpha1.CacheStatus)
+
+							// Build up the first GKMCacheNode.Status.CacheStatuses[name][resolvedDigest]
+							cacheStatus = gkmv1alpha1.CacheStatus{}
+
+							// Make sure KubeAPI is called to write this GKMCacheNode or ClusterGKMCacheNode
+							// below once some work is done.
+							updated = true
+							updateReason = "Cache Allocation"
+						}
+
+						// Loop through the list of Namespaces. For GKMCache, it's just the namespace
+						// GKMCache is created in. For ClusterGKMCache, it's the Workload Namespace list
+						// that was provided in ClusterGKMCache.
+						namespaceList := gkmCache.GetWorkloadNamespaces()
+						if len(namespaceList) == 0 {
+							if gkmCache.GetNamespace() == "" {
+								r.Logger.Info("No namespaces in ClusterGKMCache Spec.WorkloadNamespaces, so no PVCs created",
+									"Namespace", gkmCache.GetNamespace(),
+									"Name", gkmCache.GetName(),
+								)
+							}
+						}
+						for _, pvcNamespace := range namespaceList {
+							var pvcStatus gkmv1alpha1.PvcStatus
+							skipPvcCopy := false
+
+							// CREATE or UPDATE
+							if !cacheDeleting {
+								// Get the PVC Status, which is the Per Namespace PV and PVC information.
+								if cacheStatus.PvcStatus == nil {
+									cacheStatus.PvcStatus = make(map[string]gkmv1alpha1.PvcStatus)
+									updated = true
+									updateReason = "PvcStatus Allocation"
+								}
+
+								var pvcStatusExisted bool
+								pvcStatus, pvcStatusExisted = cacheStatus.PvcStatus[pvcNamespace]
+								if !pvcStatusExisted {
+									pvcStatus = gkmv1alpha1.PvcStatus{}
+									pvcStatus.PvcOwner = gkmCache.GetPvcOwner()
+									gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondPending.Condition())
+									updated = true
+									updateReason = "PvcStatus Initialization"
+								}
+
+								// Manage PV, PVC and Job used for extracted GPU Kernel Cache
+								if pvcUpdated, pvcUpdateReason, pending, err := r.managePvcStatusModify(
+									ctx,
+									reconciler,
+									&gkmCache,
+									gkmCacheNode,
+									&cacheStatus,
+									&pvcStatus,
+									pvcNamespace,
+									resolvedDigest,
+									capacity,
+								); err != nil {
+									errorHit = true
+									continue
+								} else if pvcUpdated {
+									updated = true
+									updateReason = pvcUpdateReason
+								} else if pending {
+									stillInUse = true
+									cacheInUse = true
+								}
+							} else {
+								// DELETE
+								pvcInUse := false
+
+								// Get the PVC Status, which is the Per Namespace PV and PVC information.
+								// If it doesn't exist for this Namespace, then move on to the next Namespace.
+								if cacheStatus.PvcStatus == nil {
+									continue
+								}
+
+								var pvcStatusExisted bool
+								pvcStatus, pvcStatusExisted = cacheStatus.PvcStatus[pvcNamespace]
+								if !pvcStatusExisted {
+									continue
+								}
+
+								nodeName := r.NodeName
+								// If there are more than one namespace associated with this Digest,
+								// use blank NodeName. When the delete looks to see if any Pods are using
+								// the PVC, it will not filter on just this node and will properly leave
+								// objects in place that are being used.
+								if len(cacheStatus.PvcStatus) > 1 {
+									nodeName = ""
+								}
+
+								// If Owner is Agent, then attempt to delete Job, PVC and PV. Otherwise,
+								// there is nothing to do here.
+								if gkmCache.GetPvcOwner() == gkmv1alpha1.PvcOwnerAgent {
+									var pvcDeleting bool
+									if updated, updateReason, pvcInUse, pvcDeleting, err = common.ManagePvcStatusDelete(
+										ctx,
+										r.Client,
+										gkmCache.GetNamespace(),
+										gkmCache.GetName(),
+										nodeName,
+										&pvcStatus,
+										gkmv1alpha1.PvcOwnerAgent,
+										pvcNamespace,
+										resolvedDigest,
+										r.Logger,
+									); err != nil {
+										errorHit = true
+										continue
+									} else if pvcInUse || pvcDeleting {
+										cacheInUse = true
+										stillInUse = true
+										if !gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+											gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondDeleting.Condition())
+											updated = true
+											updateReason = "Update Condition to Deleting"
+										}
+									}
+								} else {
+									// For Operator managed, determine if still in use
+									podUseCnt := common.GetPvcUsedByList(
+										ctx,
+										r.Client,
+										"", // NodeName,
+										pvcNamespace,
+										pvcStatus.PvcName,
+										r.Logger,
+									)
+									if podUseCnt != 0 {
+										pvcInUse = true
+										cacheInUse = true
+										stillInUse = true
+										if !gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+											gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondDeleting.Condition())
+											updated = true
+											updateReason = "Update Condition to Deleting"
+										}
+									}
+								}
+
+								// If nothing was updated, then this PVC Status can be removed.
+								if !updated && !pvcInUse {
+									delete(cacheStatus.PvcStatus, pvcNamespace)
+									updated = true
+									skipPvcCopy = true
+									updateReason = "Remove PVC Namespace entry"
+								}
+							}
+
+							if !updated {
+								// Update counts for this Namespace.
+								var cntPending bool
+								updated, updateReason, cntPending = r.addCounts(
+									ctx,
+									reconciler,
+									gkmCache.GetName(),
+									gkmCacheNode,
+									&cnts,
+									pvcNamespace,
+									&pvcStatus,
+								)
+								if cntPending {
+									stillInUse = true
+								}
+							}
+
+							if updated {
+								if !skipPvcCopy {
+									// Update the Cache Status copy of the PVC Status before writing the data.
+									cacheStatus.PvcStatus[pvcNamespace] = pvcStatus
+								}
+								break
+							}
+						} // For each Namespace
+
+						// Update with the collected counts
+						if !updated {
+							nodeStatus.Counts = cnts
+							if !reflect.DeepEqual((*gkmCacheNode).GetStatus(), nodeStatus) {
+								updated = true
+								updateReason = "Update Counts"
+							}
+						}
+
+						if updated {
+							// Update the Node Status copy of the Cache Status before writing the data.
+							cacheStatus.LastUpdated = metav1.Now()
+							nodeStatus.CacheStatuses[gkmCache.GetName()][resolvedDigest] = cacheStatus
+
+							changed, err := reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, nodeStatus, updateReason)
+							if err != nil {
+								errorHit = true
+								continue
+							} else {
+								// Update to GKMCacheNode Object for this Namespace was successful.
+								// Return and Reconcile will be retriggered with the GKMCacheNode Object.
+								r.Logger.V(1).Info("Return after NodeStatus Write", "Reason", updateReason, "changed", changed)
+								if changed {
+									return ctrl.Result{Requeue: false}, nil
+								} else {
+									return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
+								}
+							}
+						}
+						nodeCnts[gkmCache.GetName()] = cnts
+					}
+				} else {
+					// Owner (Operator or Agent) not set. Set a flag that work still needs to be done.
+					cacheInUse = true
+					stillInUse = true
+				}
+
+				// If the logic made it this far and GKMCache or ClusterGKMCache is being deleted,
+				// Then no more cleanup is needed and Finalizer can be removed.
+				if cacheDeleting {
+					cacheNodeUpdated, err := r.removeCacheFromCacheNode(
+						ctx,
+						reconciler,
+						gkmCacheNode,
+						nodeStatus,
+						gkmCache.GetNamespace(),
+						gkmCache.GetName(),
+						resolvedDigest,
+						cacheInUse,
+					)
+					if err != nil {
+						errorHit = true
+						continue
+					} else if cacheNodeUpdated {
+						// KubeAPI was called to update the GKMCacheNode Object. Return and Reconcile
+						// will be retriggered with the GKMCacheNode Object update.
+						r.Logger.V(1).Info("Return after NodeStatus Write - Delete Cache entry")
+						return ctrl.Result{Requeue: false}, nil
+						//return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
+					}
+
+					// Update counts for this GKMCache (or ClusterGKMCache).
+					// ToDo: Make sure counts get updated for deleting Caches
+					// nodeCnts[gkmCache.GetName()] = cnts
+
+					// No work done, so process next Cache instance
+					continue
+				}
+
+			} else {
+				r.Logger.Info("Unable to retrieve Status for CacheNode, but Status should exist already",
+					"Namespace", gkmCache.GetNamespace(),
+					"Name", gkmCache.GetName(),
+					"Digest", resolvedDigest)
+				continue
+			}
+		} // FOR EACH GKMCache or ClusterGKMCache
+	}
+
+	// Walk the GKMCacheNode or ClusterGKMCacheNode and determine if any PVCs are stranded.
+	// If so, see if the Pod using them is still active. If not, clean them up.
+	if strandedInUse, strandedErrFlag := r.manageStrandedPvcs(ctx, reconciler, inUseGkmCacheNodeList); strandedErrFlag {
+		errorHit = true
+	} else if strandedInUse {
+		stillInUse = true
 	}
 
 	// Return
 	if (*gkmCacheList).GetItemsLen() == 0 && !stillInUse {
 		// There are no extracted Caches on host, all cleaned up now, so nothing to do.
-		r.Logger.V(1).Info("Nothing to do")
+		r.Logger.Info("Nothing to do")
 		return ctrl.Result{Requeue: false}, nil
 	} else if errorHit {
-		r.Logger.V(1).Info("Error hit, requeue after 10 sec")
+		r.Logger.Info("Error hit, requeue after 10 sec")
 		// If an error was encountered during a single GKMCache instance, retry after a pause.
 		return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentFailure}, nil
-	} else {
-		r.Logger.V(1).Info("Need to recheck pod, requeue after 5 sec")
-		// GKMCache is Reconciled, so wake up to recheck Pod usage periodically.
+	} else if stillInUse {
+		r.Logger.Info("Processing still pending, requeue after 5 sec")
 		return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentUsagePoll}, nil
+	} else {
+		r.Logger.Info("Waiting for Pod Event ...")
+		return ctrl.Result{Requeue: false}, nil
+		//r.Logger.Info("Need to recheck pod, requeue after 5 sec")
+		// GKMCache is Reconciled, so wake up to recheck Pod usage periodically.
+		//return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentUsagePoll}, nil
 	}
 }
 
 // addGpuToCacheNode calls MCV to collect the set of detected GPUs and adds them to the
 // GKMCacheNode.Status.GpuStatuses field. This is only done once right after object creation
 // and is not refreshed.
-func (r *ReconcilerCommonAgent[C, CL, N]) addGpuToCacheNode(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) addGpuToCacheNode(
 	ctx context.Context,
-	reconciler AgentReconciler[C, CL, N],
-	gkmCacheNode *N,
+	reconciler AgentReconciler[C, CL, N, NL],
+	nodeStatus *gkmv1alpha1.GKMCacheNodeStatus,
 ) error {
 	// Retrieve GPU Data
 	gpus, err := GetGpuList(r.NoGpu, r.Logger)
@@ -514,9 +667,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) addGpuToCacheNode(
 	}
 
 	// Add GPU Data to Status
-	nodeStatus := gkmv1alpha1.GKMCacheNodeStatus{
-		NodeName: r.NodeName,
-	}
+	nodeStatus.NodeName = r.NodeName
 
 	if gpus != nil {
 		for _, gpu := range gpus.GPUs {
@@ -531,14 +682,8 @@ func (r *ReconcilerCommonAgent[C, CL, N]) addGpuToCacheNode(
 			GpuType: "None Detected",
 		})
 	}
-	nodeStatus.Counts.NodeCnt = 1
 
-	// Build up GKMCacheNode
-	err = reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, &nodeStatus, "Update GPU list")
-	if err == nil {
-		// Record the creation of GKMCacheNode/ClusterGKMCacheNode
-		reconciler.cacheNodeRecordEvent(gkmCacheNode, gkmv1alpha1.GkmCacheNodeEventReasonCreated, "", "", "", 0)
-	}
+	nodeStatus.Counts.NodeCnt = 1
 
 	return err
 }
@@ -576,9 +721,9 @@ func GetGpuList(noGpu bool, log logr.Logger) (*mcvDevices.GPUFleetSummary, error
 // addCacheFinalizerToCacheNode determines if a GKMCache Finalizer has been added to the GKMCacheNode.
 // If a GKMCache is deleted, this keeps it from being completely deleted until all associated GKMCacheNodes
 // have been deleted.
-func (r *ReconcilerCommonAgent[C, CL, N]) addCacheFinalizerToCacheNode(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) addCacheFinalizerToCacheNode(
 	ctx context.Context,
-	reconciler AgentReconciler[C, CL, N],
+	reconciler AgentReconciler[C, CL, N, NL],
 	gkmCache *C,
 	gkmCacheNode *N,
 ) (bool, error) {
@@ -605,12 +750,63 @@ func (r *ReconcilerCommonAgent[C, CL, N]) addCacheFinalizerToCacheNode(
 	return updated, nil
 }
 
+// managePvcStatusModify handles Create and Update calls. If necessary, it will handle the creation
+// of a PV, PVC or Job to extract GPU Kernel Cache to the PVC, depending on the state.
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) managePvcStatusModify(
+	ctx context.Context,
+	reconciler AgentReconciler[C, CL, N, NL],
+	gkmCache *C,
+	gkmCacheNode *N,
+	cacheStatus *gkmv1alpha1.CacheStatus,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	pvcNamespace string,
+	resolvedDigest string,
+	capacity string,
+) (bool, string, bool, error) {
+	updated := false
+	updateReason := ""
+	pending := false
+	var err error
+
+	// Manage PV and PVC
+	// If updated is already true, still manage PV and PVCs, because up to this
+	// point, it's just been initialization and allocation of structures, no
+	// actual work on kube objects.
+	if updated, updateReason, err = r.managePVandPVC(
+		ctx,
+		reconciler,
+		gkmCache,
+		gkmCacheNode,
+		pvcStatus,
+		pvcNamespace,
+		resolvedDigest,
+		capacity,
+	); err != nil || updated {
+		return updated, updateReason, pending, err
+	}
+
+	// Launch Job to Extract Cache
+	if updated, updateReason, pending, err = r.manageJob(
+		ctx,
+		gkmCache,
+		gkmCacheNode,
+		cacheStatus,
+		pvcStatus,
+		pvcNamespace,
+		resolvedDigest,
+	); err != nil || updated {
+		return updated, updateReason, pending, err
+	}
+
+	return updated, updateReason, pending, err
+}
+
 // managePVandPVC manages the PV and PVC that the GPU Kernel Cache is extracted to. If PVC does not exist, then
 // this function calls KubeAPI to create the PVC. It MAY need to create the PV first. If both are created, this
 // function determines if the PVC is in a valid state to receive the extracted GPU Kernel Cache.
-func (r *ReconcilerCommonAgent[C, CL, N]) managePVandPVC(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) managePVandPVC(
 	ctx context.Context,
-	reconciler AgentReconciler[C, CL, N],
+	reconciler AgentReconciler[C, CL, N, NL],
 	gkmCache *C,
 	gkmCacheNode *N,
 	pvcStatus *gkmv1alpha1.PvcStatus,
@@ -630,7 +826,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) managePVandPVC(
 			// In a KIND cluster, there is not a true CSI driver for storage management, so the PV must be
 			// manually created.
 			if r.NoGpu {
-				found, updatedName, err := common.PvExists(
+				_, found, updatedName, err := common.PvExists(
 					ctx,
 					r.Client,
 					(*gkmCache).GetName(),
@@ -687,7 +883,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) managePVandPVC(
 
 			// If PV was not written above, then determine if PVC needs to be created.
 			if !pvCreated {
-				found, updatedName, err := common.PvcExists(
+				_ /* pvc */, found, updatedName, err := common.PvcExists(
 					ctx,
 					r.Client,
 					(*gkmCache).GetName(),
@@ -755,7 +951,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) managePVandPVC(
 // manageJob determines if the GPU Kernel Cache has been extracted. If not, checks the condition and either
 // Launches a Job to extract it, or calls KubeAPI Server to retrieve the list of Jobs that match the labels
 // for a given Cache and Digest and determines the state.
-func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) manageJob(
 	ctx context.Context,
 	gkmCache *C,
 	gkmCacheNode *N,
@@ -763,7 +959,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 	pvcStatus *gkmv1alpha1.PvcStatus,
 	jobNamespace string,
 	resolvedDigest string,
-) (bool, bool, string, error) {
+) (bool, string, bool, error) {
 	updated := false
 	updateReason := ""
 	stillPending := false
@@ -797,9 +993,9 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 				r.NodeName,
 				(*gkmCache).GetImage(),
 				resolvedDigest,
-				pvcStatus.PvcName,
 				r.NoGpu,
 				r.ExtractImage,
+				pvcStatus,
 				(*gkmCache).GetPodTemplate(),
 				r.Logger,
 			)
@@ -809,6 +1005,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 				r.Logger.Error(err, "unable to extract cache",
 					"Namespace", (*gkmCache).GetNamespace(),
 					"Job Namespace", jobNamespace,
+					"Job Name", jobName,
 					"Name", (*gkmCache).GetName(),
 					"Image", (*gkmCache).GetImage(),
 					"Digest", resolvedDigest)
@@ -827,7 +1024,14 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 					"Job Namespace", jobNamespace,
 					"Name", (*gkmCache).GetName(),
 					"Digest", resolvedDigest)
-				return updated, stillPending, updateReason, nil
+
+				if gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+					gkmv1alpha1.SetPvcStatusConditions(pvcStatus, gkmv1alpha1.GkmCondRunning.Condition())
+					updated = true
+					updateReason = "Update Condition to Running"
+				}
+
+				return updated, updateReason, stillPending, nil
 			}
 
 			latestJob, err := common.GetLatestJob(
@@ -839,20 +1043,42 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 				r.NodeName,
 				r.Logger,
 			)
-			if err != nil {
-				return updated, stillPending, updateReason, err
+			if err != nil || latestJob == nil {
+				r.Logger.Info("Unable to get Latest Job",
+					"Namespace", (*gkmCache).GetNamespace(),
+					"Name", (*gkmCache).GetName(),
+					"Image", (*gkmCache).GetImage(),
+					"PVC Name", pvcStatus.PvcName,
+					"Job Namespace", jobNamespace,
+					"Job Name", pvcStatus.JobName,
+					"err", err,
+				)
+				if latestJob == nil {
+					stillPending = true
+				}
+				return updated, updateReason, stillPending, err
 			}
 
 			r.Logger.Info("Processing Latest Job",
 				"Namespace", (*gkmCache).GetNamespace(),
 				"Job Namespace", jobNamespace,
 				"Name", (*gkmCache).GetName(),
+				"Latest Job Name", latestJob.Name,
 				"Succeeded", latestJob.Status.Succeeded,
 				"Failed", latestJob.Status.Failed,
 				"Active", latestJob.Status.Active,
 				"Ready*", latestJob.Status.Ready,
 				"Conditions", pvcStatus.Conditions,
 			)
+
+			// Job Name is not saved on Create because the an additional hash
+			// is add to requested name. So wait to store the Job name until after
+			// a query.
+			if pvcStatus.JobName != latestJob.Name {
+				pvcStatus.JobName = latestJob.Name
+				updated = true
+				updateReason = "Set Job Name"
+			}
 
 			switch {
 			case latestJob.Status.Succeeded > 0:
@@ -874,6 +1100,8 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 					gkmv1alpha1.SetPvcStatusConditions(pvcStatus, gkmv1alpha1.GkmCondDownloading.Condition())
 					updated = true
 					updateReason = "Update Condition to Downloading"
+				} else {
+					stillPending = true
 				}
 			default:
 				stillPending = true
@@ -906,7 +1134,7 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 		}
 	}
 
-	return updated, stillPending, updateReason, err
+	return updated, updateReason, stillPending, err
 }
 
 // removeCacheFromCacheNode removes a GKMCache status from the GKMCacheNode.Status.CacheStatuses field.
@@ -916,112 +1144,316 @@ func (r *ReconcilerCommonAgent[C, CL, N]) manageJob(
 //     needs to be exited and restarted on the next call.
 //
 // - error: err was encounter during processing.
-func (r *ReconcilerCommonAgent[C, CL, N]) removeCacheFromCacheNode(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) removeCacheFromCacheNode(
 	ctx context.Context,
-	reconciler AgentReconciler[C, CL, N],
+	reconciler AgentReconciler[C, CL, N, NL],
 	gkmCacheNode *N,
+	nodeStatus *gkmv1alpha1.GKMCacheNodeStatus,
 	cacheNamespace, cacheName, digest string,
-) (bool, bool, error) {
+	inUse bool,
+) (bool, error) {
 	// Removing the Cache takes two steps:
-	// - First, deleted the extracted Cache from the host. This cannot happen if the Cache is still
-	//   in use (being used by a pod). If cache exists on host and delete succeeds, remove the Cache
-	//   from this digest from the GKMCacheNode and call KubeAPI to apply the change.
-	// - Second, delete the GKMCache specific finalizer from the GKMCacheNode.
-	//
-	// r.currCache may not be set when cleaning up stranded Cache, so don't use in this function.
-	// r.currCacheNode should be set, but if it was not found, cleanup cache on the node and skip the
-	// GKMCacheNode object updates.
+	// - First, remove this digest from the Status.Caches for the GKMCacheNode and call KubeAPI to
+	//   apply the change. This step is skipped if the PVC is still in use.
+	// - Second, delete the GKMCache specific finalizer from the GKMCacheNode. This allows the GKMCache
+	//   to be deleted. This will be done, even if the PVC is still in use.
 	updated := false
 
 	// Delete Extracted Cache from host.
-	r.Logger.Info("Cache being deleted, removing extracted cache from host",
+	r.Logger.Info("Cache being deleted, remove status cache",
 		"namespace", cacheNamespace,
 		"name", cacheName,
-		"digest", digest)
-
-	inUse := false
-	/*
-		inUse, err := database.RemoveCache(
-			cacheNamespace,
-			cacheName,
-			digest,
-			r.Logger,
-		)
-		if inUse {
-			r.Logger.Info("Not deleted, extracted Cache still in use",
-				"namespace", cacheNamespace,
-				"name", cacheName,
-				"digest", digest)
-			return inUse, updated, nil
-		} else if err != nil {
-			r.Logger.Error(err, "failed to delete extracted cache from host",
-				"namespace", cacheNamespace,
-				"name", cacheName,
-				"digest", digest)
-			return inUse, updated, err
-		}
-	*/
+		"digest", digest,
+		"inUse", inUse,
+	)
 
 	// Extracted Cache deleted from host, remove the Cache data for this Digest from the GKMCacheNode.
 	if gkmCacheNode != nil {
-		nodeStatus := (*gkmCacheNode).GetStatus()
-		if nodeStatus != nil {
-			if _, ok := nodeStatus.CacheStatuses[cacheName][digest]; ok {
-				r.Logger.Info("Deleting CacheStatus via Digest",
-					"Object", r.CrdCacheNodeStr,
-					"Namespace", cacheNamespace,
-					"Name", cacheName,
-					"CacheNodeName", (*gkmCacheNode).GetName(),
-					"Digest", digest)
-				delete(nodeStatus.CacheStatuses[cacheName], digest)
-				updated = true
-			}
-
-			// If all the Digests are removed from the given Cache, remove the Cache entry from the GKMCacheNode.
-			if _, ok := nodeStatus.CacheStatuses[cacheName]; ok {
-				if len(nodeStatus.CacheStatuses[cacheName]) == 0 {
-					r.Logger.Info("Also Deleting CacheStatus via Name from GKMCacheNode",
+		if !inUse {
+			if nodeStatus != nil {
+				if cacheStatus, ok := nodeStatus.CacheStatuses[cacheName][digest]; ok {
+					if len(cacheStatus.PvcStatus) != 0 {
+						r.Logger.Info("PvcStatus in CacheStatus still remain",
+							"Object", r.CrdCacheNodeStr,
+							"Namespace", cacheNamespace,
+							"Name", cacheName,
+							"CacheNodeName", (*gkmCacheNode).GetName(),
+							"Digest", digest,
+							"Num PVC Status", len(cacheStatus.PvcStatus),
+						)
+						for namespace, pvcStatus := range cacheStatus.PvcStatus {
+							r.Logger.Info("Deleting PvcStatus from CacheStatus",
+								"Object", r.CrdCacheNodeStr,
+								"Namespace", cacheNamespace,
+								"Name", cacheName,
+								"CacheNodeName", (*gkmCacheNode).GetName(),
+								"Digest", digest,
+								"Namespace", namespace,
+								"PVC", pvcStatus.PvcName,
+								"PV", pvcStatus.PvName,
+								"Reason", pvcStatus.Conditions[0].Type,
+							)
+							delete(cacheStatus.PvcStatus, namespace)
+						}
+					}
+					r.Logger.Info("Deleting CacheStatus via Digest",
 						"Object", r.CrdCacheNodeStr,
 						"Namespace", cacheNamespace,
 						"Name", cacheName,
-						"CacheNodeName", (*gkmCacheNode).GetName())
-					delete(nodeStatus.CacheStatuses, cacheName)
+						"CacheNodeName", (*gkmCacheNode).GetName(),
+						"Digest", digest)
+					delete(nodeStatus.CacheStatuses[cacheName], digest)
 					updated = true
 				}
-			}
 
-			if updated {
-				if err := reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, nodeStatus, "Remove Cache"); err != nil {
-					return inUse, false, err
+				// If all the Digests are removed from the given Cache, remove the Cache entry from the GKMCacheNode.
+				if _, ok := nodeStatus.CacheStatuses[cacheName]; ok {
+					if len(nodeStatus.CacheStatuses[cacheName]) == 0 {
+						r.Logger.Info("Also Deleting CacheStatus via Name from GKMCacheNode",
+							"Object", r.CrdCacheNodeStr,
+							"Namespace", cacheNamespace,
+							"Name", cacheName,
+							"CacheNodeName", cacheName)
+						delete(nodeStatus.CacheStatuses, cacheName)
+						updated = true
+					}
 				}
 
-				return inUse, updated, nil
+				if updated {
+					changed, err := reconciler.cacheNodeUpdateStatus(ctx, gkmCacheNode, nodeStatus, "Remove Cache")
+					if err != nil {
+						return false, err
+					} else if changed {
+						return changed, nil
+					} else {
+						// If the write doesn't think anything has changed, then keep going.
+						updated = false
+					}
+				}
 			}
-
-			// Cache was already removed from GKMCacheNode, so delete the GKMCache specific
-			// finalizer from the GKMCacheNode.
-			changed, err := reconciler.cacheNodeRemoveFinalizer(ctx, gkmCacheNode, cacheName)
-			if err != nil {
-				r.Logger.Error(err, "failed to delete GKMCache Finalizer from GKMCacheNode")
-				return inUse, false, err
-			}
-			return inUse, changed, nil
 		}
+
+		// Delete the GKMCache specific finalizer from the GKMCacheNode.
+		changed, err := reconciler.cacheNodeRemoveFinalizer(ctx, cacheName, gkmCacheNode)
+		if err != nil {
+			r.Logger.Error(err, "failed to delete GKMCache Finalizer from GKMCacheNode")
+			return false, err
+		}
+		return changed, nil
 	}
 
-	return inUse, updated, nil
+	return updated, nil
 }
 
-func (r *ReconcilerCommonAgent[C, CL, N]) addCounts(
+// manageStrandedPvcs walks the GKMCacheNode or ClusterGKMCacheNode and determines if any PVCs are
+// stranded (GKMCache or ClusterGKMCache was deleted but Pod was still using).  If so, see if the Pod
+// using them is still active. If not, clean them up.
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) manageStrandedPvcs(
 	ctx context.Context,
+	reconciler AgentReconciler[C, CL, N, NL],
+	inUseGkmCacheNodeList map[string]bool,
+) (bool, bool) {
+	pending := false
+	errorHit := false
+	r.Logger.V(1).Info("ENTER manageStrandedPvcs()")
+
+	filters := []client.ListOption{
+		client.MatchingLabels{
+			utils.GKMCacheLabelHostname: r.NodeName,
+		},
+	}
+	gkmCacheNodeList, err := reconciler.getCacheNodeList(ctx, filters...)
+	if err != nil {
+		errorHit = true
+		return pending, errorHit
+	}
+
+	if (*gkmCacheNodeList).GetItemsLen() == 0 {
+		// KubeAPI doesn't have any GKMCacheNode instances
+		r.Logger.V(1).Info("No GKMCacheNode entries found")
+	} else {
+		// There are GKMCacheNode instances created, so loop through each and any check if PVCs are stranded.
+		for _, gkmCacheNode := range (*gkmCacheNodeList).GetItems() {
+			// Check to see if GKMCacheNode was processed above in main loop. If so, skip over.
+			if _, ok := inUseGkmCacheNodeList[gkmCacheNode.GetName()]; ok {
+				r.Logger.V(1).Info("Skipping Cache Node because Cache still exists",
+					"Object", r.CrdCacheStr,
+					"Namespace", gkmCacheNode.GetNamespace(),
+					"Name", gkmCacheNode.GetName(),
+				)
+				continue
+			}
+
+			r.Logger.Info("Verifying Cache Node",
+				"Object", r.CrdCacheStr,
+				"Namespace", gkmCacheNode.GetNamespace(),
+				"Name", gkmCacheNode.GetName(),
+			)
+			cnts := gkmv1alpha1.CacheCounts{}
+			updated := false
+			updateReason := ""
+			nodeStatus := gkmCacheNode.GetStatus()
+			if nodeStatus != nil {
+				if len(nodeStatus.CacheStatuses) == 0 {
+					// If there are not CacheStatus entries, GKMCacheNode can be deleted.
+					if err = reconciler.deleteCacheNode(ctx, &gkmCacheNode); err != nil {
+						r.Logger.Error(err, "failed to delete GKMCacheNode")
+						errorHit = true
+					}
+				} else {
+					for cacheName, digestList := range nodeStatus.CacheStatuses {
+						for digest, cacheStatus := range digestList {
+							nodeName := r.NodeName
+							// If there are more than one namespace associated with this Digest,
+							// use blank NodeName. When the delete looks to see if any Pods are using
+							// the PVC, it will not filter on just this node and will properly leave
+							// objects in place that are being used.
+							if len(cacheStatus.PvcStatus) > 1 {
+								nodeName = ""
+							}
+							for namespace, pvcStatus := range cacheStatus.PvcStatus {
+								if gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+									r.Logger.Info("PVC is in Deleting State",
+										"Object", r.CrdCacheNodeStr,
+										"Name", cacheName,
+										"Digest", digest,
+										"Namespace", namespace,
+										"PVC", pvcStatus.PvcName,
+										"PV", pvcStatus.PvName,
+									)
+									pvcUpdated, pvcUpdateReason, pvcInUse, pvcDeleting, err := common.ManagePvcStatusDelete(
+										ctx,
+										r.Client,
+										namespace,
+										cacheName,
+										nodeName,
+										&pvcStatus,
+										gkmv1alpha1.PvcOwnerAgent,
+										namespace,
+										digest,
+										r.Logger,
+									)
+									if err != nil {
+										errorHit = true
+										continue
+									}
+									if pvcUpdated {
+										cacheStatus.PvcStatus[namespace] = pvcStatus
+										updated = true
+										updateReason = pvcUpdateReason
+									}
+									if pvcDeleting {
+										pending = true
+									}
+
+									// If nothing was updated and it's no longer being used, then this PVC Status can be removed.
+									if !updated && !pvcInUse && !pvcDeleting {
+										delete(cacheStatus.PvcStatus, namespace)
+										updated = true
+										updateReason = "Remove PVC Namespace entry"
+									}
+								}
+
+								// Update counts for this Namespace.
+								cntUpdated, cntUpdateReason, _ /* cntPending */ := r.addCounts(
+									ctx,
+									reconciler,
+									cacheName,
+									&gkmCacheNode,
+									&cnts,
+									namespace,
+									&pvcStatus,
+								)
+								if cntUpdated && !updated {
+									updated = true
+									updateReason = cntUpdateReason
+								}
+							}
+							if updated {
+								// If all the PVCs were deleted, delete this digest, otherwise updated it.
+								if len(cacheStatus.PvcStatus) == 0 {
+									r.Logger.Info("Deleting CacheStatus via Digest",
+										"Object", r.CrdCacheNodeStr,
+										"Name", cacheName,
+										"CacheNodeName", gkmCacheNode.GetName(),
+										"Digest", digest)
+									delete(nodeStatus.CacheStatuses[cacheName], digest)
+								} else {
+									// Update the Node Status copy of the Cache Status before writing the data.
+									cacheStatus.LastUpdated = metav1.Now()
+									nodeStatus.CacheStatuses[cacheName][digest] = cacheStatus
+								}
+							}
+						}
+						// If all the Digests are removed from the given Cache, remove the Cache entry from the GKMCacheNode.
+						if len(nodeStatus.CacheStatuses[cacheName]) == 0 {
+							// Delete the GKMCache specific finalizer from the GKMCacheNode.
+							updated, err := reconciler.cacheNodeRemoveFinalizer(ctx, cacheName, &gkmCacheNode)
+							if err != nil {
+								r.Logger.Error(err, "failed to delete GKMCache Finalizer from GKMCacheNode")
+								errorHit = true
+							} else if updated {
+								//pending = true
+								return pending, errorHit
+							} else {
+								r.Logger.Info("Also Deleting CacheStatus via Name from GKMCacheNode",
+									"Object", r.CrdCacheNodeStr,
+									"Name", cacheName,
+									"CacheNodeName", gkmCacheNode.GetName())
+								delete(nodeStatus.CacheStatuses, cacheName)
+								if !updated {
+									updated = true
+									updateReason = "Deleting CacheStatus"
+								}
+							}
+						}
+					}
+					nodeStatus.Counts = cnts
+					// Update with the collected counts
+					if !updated {
+						if !reflect.DeepEqual(gkmCacheNode.GetStatus(), nodeStatus) {
+							updated = true
+							updateReason = "Update Counts"
+						}
+					}
+					if updated {
+						changed, err := reconciler.cacheNodeUpdateStatus(ctx, &gkmCacheNode, nodeStatus, updateReason)
+						if err != nil {
+							errorHit = true
+							continue
+						} else if changed {
+							// Update to GKMCacheNode Object for this Namespace was successful.
+							// Return and Reconcile will be retriggered with the GKMCacheNode Object.
+							return pending, errorHit
+						}
+					}
+				}
+			}
+		}
+	}
+	return pending, errorHit
+}
+
+// addCounts examines a given PVC Status and increments counts based on the state of a given
+// PVC and if it is being used by any Pods. This function assumes that the counts were initialized
+// prior and this function is called for each PVC Status structure for a given GKMCacheNode or
+// ClusterGKMCacheNode.
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) addCounts(
+	ctx context.Context,
+	reconciler AgentReconciler[C, CL, N, NL],
+	cacheName string,
+	gkmCacheNode *N,
 	cnts *gkmv1alpha1.CacheCounts,
 	pvcNamespace string,
 	pvcStatus *gkmv1alpha1.PvcStatus,
-) (bool, string) {
-	cnts.NodeCnt = 1
-	podUseCnt := 0
+) (bool, string, bool) {
 	updated := false
 	updateReason := ""
+	pending := false
+
+	cnts.NodeCnt = 1
+	//podCnt := 0
+	podUseCnt := 0
 
 	if pvcStatus.PvcName != "" {
 		podUseCnt = common.GetPvcUsedByList(
@@ -1057,6 +1489,13 @@ func (r *ReconcilerCommonAgent[C, CL, N]) addCounts(
 			cnts.NodeNotInUseCnt = 0
 			cnts.PodRunningCnt += podUseCnt
 		}
+	case string(gkmv1alpha1.GkmCondDeleting):
+		cnts.PodDeletingCnt += podUseCnt
+		cnts.NodeInUseCnt = 1
+		cnts.NodeNotInUseCnt = 0
+		if !reconciler.hasCacheNodeFinalizer(cacheName, gkmCacheNode) {
+			cnts.NodeCnt = 0
+		}
 	case string(gkmv1alpha1.GkmCondError):
 		cnts.NodeErrorCnt++
 	case string(gkmv1alpha1.GkmCondUnloadError):
@@ -1065,72 +1504,10 @@ func (r *ReconcilerCommonAgent[C, CL, N]) addCounts(
 		// PodOutdatedCnt is collected in the Garbage Collection portion of the Reconcile loop.
 	}
 
-	return updated, updateReason
+	return updated, updateReason, pending
 }
 
-// processPodListChanges is used to walk the list of pods in the usage data and the list
-// of pods for a given cache in the Node object. CSI Agent detects pods coming and going and
-// adds them to the usage data. The Agent periodically polls the usage data for changes.
-// Several pods could come and go in between the polling period, so this function walks
-// each list and publishes the changes in Events in the Node Object.
-func (r *ReconcilerCommonAgent[C, CL, N]) processPodListChanges(
-	reconciler AgentReconciler[C, CL, N],
-	gkmCache *C,
-	gkmCacheNode *N,
-	oldPodList, newPodList []gkmv1alpha1.PodData,
-) {
-	currPodCnt := len(oldPodList)
-
-	// Look for pods removed from Node Object by walking the OldPodList (which is currently
-	// in the Node Object) and see which pods aren't in the NewPodList (the usage data)
-	for _, currPod := range oldPodList {
-		found := false
-		for _, pod := range newPodList {
-			if currPod.PodNamespace == pod.PodNamespace &&
-				currPod.PodName == pod.PodName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			currPodCnt--
-			reconciler.cacheNodeRecordEvent(
-				gkmCacheNode,
-				gkmv1alpha1.GkmCacheNodeEventReasonCacheReleased,
-				(*gkmCache).GetName(),
-				currPod.PodNamespace,
-				currPod.PodName,
-				currPodCnt,
-			)
-		}
-	}
-
-	// Look for pods added to Node Object by walking the NewPodList (the usage data)
-	// and see which pods aren't in the OldPodLis t(which is currently in the Node Object)
-	for _, currPod := range newPodList {
-		found := false
-		for _, pod := range oldPodList {
-			if currPod.PodNamespace == pod.PodNamespace &&
-				currPod.PodName == pod.PodName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			currPodCnt++
-			reconciler.cacheNodeRecordEvent(
-				gkmCacheNode,
-				gkmv1alpha1.GkmCacheNodeEventReasonCacheUsed,
-				(*gkmCache).GetName(),
-				currPod.PodNamespace,
-				currPod.PodName,
-				currPodCnt,
-			)
-		}
-	}
-}
-
-func (r *ReconcilerCommonAgent[C, CL, N]) getImageToGpuList(
+func (r *ReconcilerCommonAgent[C, CL, N, NL]) getImageToGpuList(
 	gkmCache *C,
 	resolvedDigest string,
 	cacheStatus *gkmv1alpha1.CacheStatus,

--- a/internal/controller/gkm-agent/namespace_gkmcache_controller.go
+++ b/internal/controller/gkm-agent/namespace_gkmcache_controller.go
@@ -21,11 +21,13 @@ package gkmAgent
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,8 +35,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gkmv1alpha1 "github.com/redhat-et/GKM/api/v1alpha1"
+	"github.com/redhat-et/GKM/pkg/common"
 	"github.com/redhat-et/GKM/pkg/utils"
 )
 
@@ -50,7 +54,12 @@ import (
 
 // GKMCacheAgentReconciler reconciles a GKMCache object
 type GKMCacheAgentReconciler struct {
-	ReconcilerCommonAgent[gkmv1alpha1.GKMCache, gkmv1alpha1.GKMCacheList, gkmv1alpha1.GKMCacheNode]
+	ReconcilerCommonAgent[
+		gkmv1alpha1.GKMCache,
+		gkmv1alpha1.GKMCacheList,
+		gkmv1alpha1.GKMCacheNode,
+		gkmv1alpha1.GKMCacheNodeList,
+	]
 }
 
 // GKMCacheAgentReconciler reconciles/reads each GKMCache object (read-only) and creates and
@@ -65,12 +74,7 @@ func (r *GKMCacheAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 // SetupWithManager sets up the controller with the Manager.
 func (r *GKMCacheAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gkmv1alpha1.GKMCache{},
-			builder.WithPredicates(predicate.And(
-				predicate.GenerationChangedPredicate{},
-				predicate.ResourceVersionChangedPredicate{},
-			)),
-		).
+		For(&gkmv1alpha1.GKMCache{}).
 		// Trigger reconciliation if the GKMCacheNode for this node is modified.
 		// Own() doesn't work because the GKMCacheNode is per Namespace and the
 		// GKMCache is not an ownerRef, because there may be multiple GKMCache
@@ -79,6 +83,11 @@ func (r *GKMCacheAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&gkmv1alpha1.GKMCacheNode{},
 			&handler.EnqueueRequestForObject{},
 			builder.WithPredicates((GkmCacheNodePredicate(r.NodeName))),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueGKMCacheNode),
+			builder.WithPredicates(common.PodPredicate(r.NodeName)),
 		).
 		Complete(r)
 }
@@ -101,10 +110,28 @@ func GkmCacheNodePredicate(nodeName string) predicate.Funcs {
 	}
 }
 
+func (r *GKMCacheAgentReconciler) enqueueGKMCacheNode(ctx context.Context, obj client.Object) []reconcile.Request {
+	crList := &gkmv1alpha1.GKMCacheNodeList{}
+	if err := r.List(ctx, crList); err != nil || len(crList.Items) == 0 {
+		return nil
+	}
+
+	cr := crList.Items[0]
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: cr.Namespace,
+				Name:      cr.Name,
+			},
+		},
+	}
+}
+
 // GetCacheList gets the list of GKMCache objects from KubeAPI Server.
 func (r *GKMCacheAgentReconciler) getCacheList(
 	ctx context.Context,
-	opts []client.ListOption,
+	opts ...client.ListOption,
 ) (*gkmv1alpha1.GKMCacheList, error) {
 	// Get the list of existing GKMCache objects
 	cacheList := &gkmv1alpha1.GKMCacheList{}
@@ -114,6 +141,21 @@ func (r *GKMCacheAgentReconciler) getCacheList(
 	}
 
 	return cacheList, nil
+}
+
+// getCacheNodeList gets the list of GKMCacheNode objects from KubeAPI Server.
+func (r *GKMCacheAgentReconciler) getCacheNodeList(
+	ctx context.Context,
+	opts ...client.ListOption,
+) (*gkmv1alpha1.GKMCacheNodeList, error) {
+	// Get the list of existing GKMCache objects
+	cacheNodeList := &gkmv1alpha1.GKMCacheNodeList{}
+	if err := r.List(ctx, cacheNodeList, opts...); err != nil {
+		r.Logger.Error(err, "failed to list", "Object", r.CrdCacheStr)
+		return nil, err
+	}
+
+	return cacheNodeList, nil
 }
 
 // getCacheNode gets the GKMCacheNode object from KubeAPI Server for the current
@@ -193,29 +235,95 @@ func (r *GKMCacheAgentReconciler) cacheNodeUpdateStatus(
 	gkmCacheNode *gkmv1alpha1.GKMCacheNode,
 	nodeStatus *gkmv1alpha1.GKMCacheNodeStatus,
 	reason string,
-) error {
-	gkmCacheNode.Status = *nodeStatus.DeepCopy()
+) (bool, error) {
+	change := true
 
-	r.Logger.Info("Calling KubeAPI to Update GKMCacheNode Status",
-		"reason", reason,
-		"Namespace", gkmCacheNode.Namespace,
-		"CacheNodeName", gkmCacheNode.Name,
-	)
-	if err := r.Status().Update(ctx, gkmCacheNode); err != nil {
-		if strings.Contains(err.Error(), "object has been modified") {
-			r.Logger.Info("failed to update GKMCacheNode Status - outdated",
-				"reason", reason,
-				"Namespace", gkmCacheNode.Namespace,
-				"CacheNodeName", gkmCacheNode.Name,
-				"Error", err,
-			)
+	if !reflect.DeepEqual(gkmCacheNode.GetStatus().DeepCopy(), nodeStatus) {
+		gkmCacheNode.Status = *nodeStatus.DeepCopy()
+
+		r.Logger.Info("Calling KubeAPI to Update GKMCacheNode Status",
+			"reason", reason,
+			"Namespace", gkmCacheNode.Namespace,
+			"CacheNodeName", gkmCacheNode.Name,
+		)
+		if err := r.Status().Update(ctx, gkmCacheNode); err != nil {
+			if strings.Contains(err.Error(), "object has been modified") {
+				r.Logger.Info("failed to update GKMCacheNode Status - outdated",
+					"reason", reason,
+					"Namespace", gkmCacheNode.Namespace,
+					"CacheNodeName", gkmCacheNode.Name,
+					"Error", err,
+				)
+			} else {
+				r.Logger.Error(err, "failed to update GKMCacheNode Status",
+					"reason", reason,
+					"Namespace", gkmCacheNode.Namespace,
+					"CacheNodeName", gkmCacheNode.Name,
+				)
+			}
+			return change, err
+		}
+	} else {
+		change = false
+		r.Logger.Info("cacheNodeUpdateStatus() called but nothing changed",
+			"reason", reason,
+			"Namespace", gkmCacheNode.Namespace,
+			"CacheNodeName", gkmCacheNode.Name,
+		)
+		tmpNodeStatus := gkmCacheNode.GetStatus()
+		if tmpNodeStatus != nil {
+			if len(tmpNodeStatus.CacheStatuses) == 0 {
+				r.Logger.Info("cacheNodeUpdateStatus() - TMP No CacheStatuses",
+					"Namespace", gkmCacheNode.Namespace,
+					"CacheNodeName", gkmCacheNode.Name,
+				)
+			} else {
+				for cacheName, digestList := range tmpNodeStatus.CacheStatuses {
+					r.Logger.Info("cacheNodeUpdateStatus() - TMP", "cacheName", cacheName)
+					for digest, cacheStatus := range digestList {
+						r.Logger.Info("cacheNodeUpdateStatus() - TMP", "digest", digest)
+						for namespace, pvcStatus := range cacheStatus.PvcStatus {
+							r.Logger.Info("cacheNodeUpdateStatus() - TMP", "namespace", namespace, "pvcStatus", pvcStatus)
+						}
+					}
+				}
+			}
 		} else {
-			r.Logger.Error(err, "failed to update GKMCacheNode Status",
-				"reason", reason,
+			r.Logger.Info("cacheNodeUpdateStatus() - TMP - No Node Status",
 				"Namespace", gkmCacheNode.Namespace,
 				"CacheNodeName", gkmCacheNode.Name,
 			)
 		}
+
+		if len(nodeStatus.CacheStatuses) == 0 {
+			r.Logger.Info("cacheNodeUpdateStatus() - No CacheStatuses",
+				"Namespace", gkmCacheNode.Namespace,
+				"CacheNodeName", gkmCacheNode.Name,
+			)
+		} else {
+			for cacheName, digestList := range nodeStatus.CacheStatuses {
+				r.Logger.Info("cacheNodeUpdateStatus()", "cacheName", cacheName)
+				for digest, cacheStatus := range digestList {
+					r.Logger.Info("cacheNodeUpdateStatus()", "digest", digest)
+					for namespace, pvcStatus := range cacheStatus.PvcStatus {
+						r.Logger.Info("cacheNodeUpdateStatus()", "namespace", namespace, "pvcStatus", pvcStatus)
+					}
+				}
+			}
+		}
+	}
+
+	return change, nil
+}
+
+// deleteCacheNode deletes the GKMCacheNode Object for this Node.
+func (r *GKMCacheAgentReconciler) deleteCacheNode(ctx context.Context, gkmCacheNode *gkmv1alpha1.GKMCacheNode) error {
+	r.Logger.Info("Delete GKMCacheNode object",
+		"Namespace", gkmCacheNode.Namespace, "CacheNodeName", gkmCacheNode.Name)
+
+	if err := r.Delete(ctx, gkmCacheNode); err != nil {
+		r.Logger.Error(err, "failed to delete GKMCacheNode object",
+			"Namespace", gkmCacheNode.Namespace, "CacheNodeName", gkmCacheNode.Name)
 		return err
 	}
 
@@ -239,7 +347,7 @@ func (r *GKMCacheAgentReconciler) cacheNodeAddFinalizer(
 	gkmCacheNode *gkmv1alpha1.GKMCacheNode,
 	cacheName string,
 ) (bool, error) {
-	if changed := controllerutil.AddFinalizer(gkmCacheNode, r.getCacheNodeFinalizer(cacheName)); changed {
+	if changed := controllerutil.AddFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)); changed {
 		r.Logger.Info("Calling KubeAPI to add GKMCache Finalizer to GKMCacheNode",
 			"Namespace", gkmCacheNode.Namespace,
 			"Name", cacheName,
@@ -258,17 +366,26 @@ func (r *GKMCacheAgentReconciler) cacheNodeAddFinalizer(
 	return false, nil
 }
 
-// getCacheNodeFinalizer returns the finalizer that is added to the GKMCacheNode object.
-func (r *GKMCacheAgentReconciler) getCacheNodeFinalizer(name string) string {
+// getCacheNodeFinalizerName returns the finalizer that is added to the GKMCacheNode object.
+func (r *GKMCacheAgentReconciler) getCacheNodeFinalizerName(name string) string {
 	return utils.GkmCacheNodeFinalizerPrefix + name + utils.GkmCacheNodeFinalizerSubstring
+}
+
+// hasCacheNodeFinalizer determines if GKMCacheNode object has a finalizer added.
+func (r *GKMCacheAgentReconciler) hasCacheNodeFinalizer(cacheName string, gkmCacheNode *gkmv1alpha1.GKMCacheNode) bool {
+	if controllerutil.ContainsFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)) {
+		return true
+	} else {
+		return false
+	}
 }
 
 func (r *GKMCacheAgentReconciler) cacheNodeRemoveFinalizer(
 	ctx context.Context,
-	gkmCacheNode *gkmv1alpha1.GKMCacheNode,
 	cacheName string,
+	gkmCacheNode *gkmv1alpha1.GKMCacheNode,
 ) (bool, error) {
-	if changed := controllerutil.RemoveFinalizer(gkmCacheNode, r.getCacheNodeFinalizer(cacheName)); changed {
+	if changed := controllerutil.RemoveFinalizer(gkmCacheNode, r.getCacheNodeFinalizerName(cacheName)); changed {
 		r.Logger.Info("Calling KubeAPI to delete GKMCache Finalizer from GKMCacheNode",
 			"Namespace", gkmCacheNode.Namespace,
 			"Name", cacheName,

--- a/internal/controller/gkm-operator/cluster_gkmcache_controller.go
+++ b/internal/controller/gkm-operator/cluster_gkmcache_controller.go
@@ -20,18 +20,26 @@ package gkmOperator
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gkmv1alpha1 "github.com/redhat-et/GKM/api/v1alpha1"
+	"github.com/redhat-et/GKM/pkg/common"
 	"github.com/redhat-et/GKM/pkg/utils"
 )
 
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gkm.io,resources=clustergkmcaches,verbs=get;list;watch;create;update;patch;delete
@@ -74,7 +82,29 @@ func (r *ClusterGKMCacheOperatorReconciler) SetupWithManager(mgr ctrl.Manager) e
 		Watches(&gkmv1alpha1.ClusterGKMCacheNode{},
 			&handler.EnqueueRequestForObject{},
 		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueClusterGKMCache),
+			builder.WithPredicates(common.PodPredicate("" /* NodeName*/)),
+		).
 		Complete(r)
+}
+
+func (r *ClusterGKMCacheOperatorReconciler) enqueueClusterGKMCache(ctx context.Context, obj client.Object) []reconcile.Request {
+	crList := &gkmv1alpha1.ClusterGKMCacheList{}
+	if err := r.List(ctx, crList); err != nil || len(crList.Items) == 0 {
+		return nil
+	}
+
+	cr := crList.Items[0]
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name: cr.Name,
+			},
+		},
+	}
 }
 
 // GetCacheList gets the list of GKMCache objects from KubeAPI Server.
@@ -113,30 +143,40 @@ func (r *ClusterGKMCacheOperatorReconciler) cacheUpdateStatus(
 	gkmCache *gkmv1alpha1.ClusterGKMCache,
 	cacheStatus *gkmv1alpha1.GKMCacheStatus,
 	reason string,
-) error {
-	gkmCache.Status = *cacheStatus.DeepCopy()
+) (bool, error) {
+	changed := true
 
-	r.Logger.Info("Calling KubeAPI to Update ClusterGKMCache Status",
-		"reason", reason,
-		"CacheName", gkmCache.Name,
-	)
-	if err := r.Status().Update(ctx, gkmCache); err != nil {
-		if strings.Contains(err.Error(), "object has been modified") {
-			r.Logger.Info("failed to update ClusterGKMCache Status - outdated",
-				"reason", reason,
-				"CacheName", gkmCache.Name,
-				"Error", err,
-			)
-		} else {
-			r.Logger.Error(err, "failed to update ClusterGKMCache Status",
-				"reason", reason,
-				"CacheName", gkmCache.Name,
-			)
+	if !reflect.DeepEqual(gkmCache.GetStatus().DeepCopy(), cacheStatus) {
+		gkmCache.Status = *cacheStatus.DeepCopy()
+
+		r.Logger.Info("Calling KubeAPI to Update ClusterGKMCache Status",
+			"reason", reason,
+			"CacheName", gkmCache.Name,
+		)
+		if err := r.Status().Update(ctx, gkmCache); err != nil {
+			if strings.Contains(err.Error(), "object has been modified") {
+				r.Logger.Info("failed to update ClusterGKMCache Status - outdated",
+					"reason", reason,
+					"CacheName", gkmCache.Name,
+					"Error", err,
+				)
+			} else {
+				r.Logger.Error(err, "failed to update ClusterGKMCache Status",
+					"reason", reason,
+					"CacheName", gkmCache.Name,
+				)
+			}
+			return changed, err
 		}
-		return err
+	} else {
+		changed = false
+		r.Logger.Info("cacheUpdateStatus() called but nothing changed",
+			"reason", reason,
+			"CacheName", gkmCache.Name,
+		)
 	}
 
-	return nil
+	return changed, nil
 }
 
 func (r *ClusterGKMCacheOperatorReconciler) isBeingDeleted(gkmCache *gkmv1alpha1.ClusterGKMCache) bool {

--- a/internal/controller/gkm-operator/common.go
+++ b/internal/controller/gkm-operator/common.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -123,7 +124,7 @@ type OperatorReconciler[
 	// ClusterGKMCacheNode objects.
 	getCacheNodeList(ctx context.Context, opts []client.ListOption) (*NL, error)
 
-	cacheUpdateStatus(ctx context.Context, gkmCache *C, cacheStatus *gkmv1alpha1.GKMCacheStatus, reason string) error
+	cacheUpdateStatus(ctx context.Context, gkmCache *C, cacheStatus *gkmv1alpha1.GKMCacheStatus, reason string) (bool, error)
 
 	isBeingDeleted(gkmCache *C) bool
 
@@ -149,6 +150,8 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) reconcileCommonOperator(
 
 	r.Logger.V(1).Info("Start reconcileCommonOperator()")
 
+	inUseGkmCacheList := make(map[string]bool)
+
 	// Get the list of existing GKMCache or ClusterGKMCache objects from KubeAPI Server.
 	gkmCacheList, err := reconciler.getCacheList(ctx, []client.ListOption{})
 	if err != nil {
@@ -160,265 +163,44 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) reconcileCommonOperator(
 
 	if (*gkmCacheList).GetItemsLen() == 0 {
 		// KubeAPI doesn't have any GKMCache instances, so nothing to do.
-		r.Logger.Info("GKMCache Status Controller found no caches")
-		return ctrl.Result{Requeue: false}, nil
-	}
-
-	// There are GKMCache instances created, so loop through each and reconcile each.
-	for _, gkmCache := range (*gkmCacheList).GetItems() {
-		r.Logger.V(1).Info("Reconciling",
-			"Object", r.CrdCacheStr,
-			"Namespace", gkmCache.GetNamespace(),
-			"Name", gkmCache.GetName(),
-			"StorageClass", gkmCache.GetStorageClassName(),
-			"PvcOwner", gkmCache.GetPvcOwner(),
-			"AccessMode", gkmCache.GetAccessMode(),
-		)
-
-		// See if Digest has been set (Webhook validated and image is allowed to be used).
-		annotations := gkmCache.GetAnnotations()
-		resolvedDigest, digestFound := annotations[utils.GKMCacheAnnotationResolvedDigest]
-		if !digestFound || resolvedDigest == "" {
-			// If digest not found, Webhook is still processing, skip over and reconcile on
-			// next time in loop.
-			r.Logger.Info("Digest NOT Found, Webhook still processing.",
+		r.Logger.V(1).Info("GKMCache Status Controller found no caches")
+	} else {
+		// There are GKMCache instances created, so loop through each and reconcile each.
+		for _, gkmCache := range (*gkmCacheList).GetItems() {
+			r.Logger.V(1).Info("Reconciling",
 				"Object", r.CrdCacheStr,
 				"Namespace", gkmCache.GetNamespace(),
-				"Name", gkmCache.GetName())
-			continue
-		}
-		capacity, capFound := annotations[utils.GKMCacheAnnotationCacheSizeBytes]
-		if !capFound {
-			capacity = "1Gi"
-			r.Logger.Info("Capacity NOT Found, setting to 1GB")
-		}
+				"Name", gkmCache.GetName(),
+				"StorageClass", gkmCache.GetStorageClassName(),
+				"PvcOwner", gkmCache.GetPvcOwner(),
+				"AccessMode", gkmCache.GetAccessMode(),
+			)
 
-		if !reconciler.isBeingDeleted(&gkmCache) {
-			// Add Finalizer to GKMCache or ClusterGKMCache if not there. This is a KubeAPI call,
-			// so return if finalizer needed to be added.
-			changed, err := reconciler.cacheAddFinalizer(ctx, &gkmCache)
-			if err != nil {
-				errorHit = true
-				continue
-			} else if changed {
-				// GKMCache object was updated. Return and change will retrigger a new reconcile.
-				return ctrl.Result{Requeue: false}, nil
-			}
-		}
+			cacheDeleting := reconciler.isBeingDeleted(&gkmCache)
+			inUseGkmCacheList[gkmCache.GetName()] = cacheDeleting
 
-		gkmCacheStatus := gkmCache.GetStatus().DeepCopy()
-		gkmCacheStatus.Counts = gkmv1alpha1.CacheCounts{}
-		gkmCacheStatus.ResolvedDigest = resolvedDigest
-
-		if gkmCacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerUnknown || gkmCacheStatus.PvcOwner == "" {
-			// Initialize the condition to pending.
-			r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondPending.Condition())
-
-			gkmCacheStatus.PvcOwner = gkmv1alpha1.PvcOwnerAgent
-			accessMode := gkmCache.GetAccessMode()
-			for _, mode := range accessMode {
-				if mode == corev1.ReadOnlyMany {
-					gkmCacheStatus.PvcOwner = gkmv1alpha1.PvcOwnerOperator
-				}
-			}
-			r.Logger.Info("Owner not set, setting now", "Updated Value", gkmCacheStatus.PvcOwner)
-		}
-
-		// If the PVC AccessMode is ReadOnlyMany, then only one PVC per Namespace needs to be created
-		// and the storage backend will handle propagating the extracted cache to each node. Since
-		// there is only one, the Operator handles the creation here.
-		if gkmCacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerOperator {
-			updated := false
-			updateReason := ""
-
-			// Loop through the list of Namespaces. For GKMCache, it's just the namespace
-			// GKMCache is created in. For ClusterGKMCache, it's the Workload Namespace list
-			// that was provided in ClusterGKMCache.
-			namespaceList := gkmCache.GetWorkloadNamespaces()
-			if len(namespaceList) == 0 {
-				if gkmCache.GetNamespace() == "" {
-					r.Logger.Info("No namespaces in ClusterGKMCache Spec.WorkloadNamespaces, so no PVCs created",
-						"Namespace", gkmCache.GetNamespace(),
-						"Name", gkmCache.GetName(),
-					)
-				}
-			}
-			for _, pvcNamespace := range namespaceList {
-				// Get the PVC Status, which is the Per Namespace PV and PVC information.
-				if gkmCacheStatus.PvcStatus == nil {
-					gkmCacheStatus.PvcStatus = make(map[string]gkmv1alpha1.PvcStatus)
-					updated = true
-					updateReason = "PvcStatus Allocation"
-				}
-
-				pvcStatus, pvcStatusExisted := gkmCacheStatus.PvcStatus[pvcNamespace]
-				if !pvcStatusExisted {
-					pvcStatus = gkmv1alpha1.PvcStatus{}
-					gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondPending.Condition())
-					updated = true
-					updateReason = "PvcStatus Initialization"
-				}
-
-				r.Logger.Info("Owner Operator, manage PV/PVC",
+			// See if Digest has been set (Webhook validated and image is allowed to be used).
+			annotations := gkmCache.GetAnnotations()
+			resolvedDigest, digestFound := annotations[utils.GKMCacheAnnotationResolvedDigest]
+			if !digestFound || resolvedDigest == "" {
+				// If digest not found, Webhook is still processing, skip over and reconcile on
+				// next time in loop.
+				r.Logger.Info("Digest NOT Found, Webhook still processing.",
+					"Object", r.CrdCacheStr,
 					"Namespace", gkmCache.GetNamespace(),
-					"Name", gkmCache.GetName(),
-					"PVC Namespace", pvcNamespace,
-					"Starting PV", pvcStatus.PvName,
-					"Starting PVC", pvcStatus.PvcName)
-
-				// Since Operator owns PV/PVC, manage each now.
-				// If updated is already true, still manage PV and PVCs, because up to this
-				// point, it's just been initialization and allocation of structures, no
-				// actual work on kube objects.
-				if pvcUpdated, pvcReason, err := r.managePVandPVC(
-					ctx,
-					reconciler,
-					&gkmCache,
-					gkmCacheStatus,
-					&pvcStatus,
-					pvcNamespace,
-					capacity,
-				); err != nil {
-					errorHit = true
-					continue
-				} else if pvcUpdated {
-					updated = true
-					updateReason = pvcReason
-				}
-
-				if !updated {
-					// Launch Job to Extract Cache
-					jobUpdated, pending, jobUpdateReason, err := r.manageJob(
-						ctx,
-						&gkmCache,
-						&pvcStatus,
-						pvcNamespace,
-						resolvedDigest,
-					)
-					if err != nil {
-						errorHit = true
-						continue
-					}
-					if jobUpdated {
-						updated = true
-						updateReason = jobUpdateReason
-					}
-					if pending {
-						stillInUse = true
-					}
-				}
-
-				if updated {
-					// Update the Cache Status copy of the PVC Status before writing the data below.
-					gkmCacheStatus.PvcStatus[pvcNamespace] = pvcStatus
-					break
-				}
+					"Name", gkmCache.GetName())
+				continue
+			}
+			capacity, capFound := annotations[utils.GKMCacheAnnotationCacheSizeBytes]
+			if !capFound {
+				capacity = "1Gi"
+				r.Logger.Info("Capacity NOT Found, setting to 1GB")
 			}
 
-			// Call KubeAPI to update the Status for the GKMCache (or ClusterGKMCache) that was
-			// modified above.
-			if updated {
-				gkmCacheStatus.LastUpdated = metav1.Now()
-				err = reconciler.cacheUpdateStatus(ctx, &gkmCache, gkmCacheStatus, updateReason)
-				if err != nil {
-					errorHit = true
-					continue
-				} else {
-					// GKMCacheNode Object was updated successfully.
-					// Return and Reconcile will be retriggered with the GKMCacheNode Object.
-					//return ctrl.Result{Requeue: false}, nil
-					return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
-				}
-			}
-		}
-
-		// Call KubeAPI to Retrieve the list of GKMCacheNodes for this Namespace.
-		// Should be one per Node if GKMCache was created in the Namespace.
-		opts := []client.ListOption{
-			client.InNamespace(gkmCache.GetNamespace()),
-		}
-		gkmCacheNodeList, err := reconciler.getCacheNodeList(ctx, opts)
-		if err != nil {
-			// Error returned if unable to call KubeAPI. Don't block Reconcile on one instance,
-			// log and go to next GKMCache.
-			r.Logger.Error(err, "failed to get GKMCacheNode List", "Namespace", gkmCache.GetNamespace(), "Name", gkmCache.GetName())
-			errorHit = true
-			continue
-		}
-
-		// Loop through each GKMCacheNode (i.e. each Node)
-		for _, gkmCacheNode := range (*gkmCacheNodeList).GetItems() {
-			nodeStatus := gkmCacheNode.GetStatus()
-			if nodeStatus != nil {
-				// See if this GKMCache has been added to the GKMCacheNode
-				if _, ok := nodeStatus.CacheStatuses[gkmCache.GetName()]; ok {
-					// This Cache was found in a GKMCacheNode instance
-					gkmCacheStatus.Counts.NodeCnt += nodeStatus.Counts.NodeCnt
-					gkmCacheStatus.Counts.NodeInUseCnt += nodeStatus.Counts.NodeInUseCnt
-					gkmCacheStatus.Counts.NodeNotInUseCnt += nodeStatus.Counts.NodeNotInUseCnt
-					gkmCacheStatus.Counts.NodeErrorCnt += nodeStatus.Counts.NodeErrorCnt
-					gkmCacheStatus.Counts.PodRunningCnt += nodeStatus.Counts.PodRunningCnt
-					gkmCacheStatus.Counts.PodOutdatedCnt += nodeStatus.Counts.PodOutdatedCnt
-				}
-			}
-		}
-
-		r.Logger.V(1).Info("Processed GKMCache",
-			"Namespace", gkmCache.GetNamespace(),
-			"CacheName", gkmCache.GetName(),
-			"NodeCnt", gkmCacheStatus.Counts.NodeCnt,
-			"NodeInUse", gkmCacheStatus.Counts.NodeInUseCnt,
-			"NodeNotInUse", gkmCacheStatus.Counts.NodeNotInUseCnt,
-			"NodeError", gkmCacheStatus.Counts.NodeErrorCnt,
-			"PodRunning", gkmCacheStatus.Counts.PodRunningCnt,
-			"PodOutdated", gkmCacheStatus.Counts.PodOutdatedCnt,
-			"Conditions", gkmCacheStatus.Conditions,
-		)
-
-		if !reconciler.isBeingDeleted(&gkmCache) {
-			reason := "Update Counts"
-			// Adjust Condition if need. If Operator owns the PVC extraction, then
-			// wait for Pending and Downloading state to clear before adjusting based
-			// on GKMCacheNode or ClusterGKMCacheNode counts.
-			if gkmCacheStatus.Counts.NodeErrorCnt != 0 {
-				if !gkmv1alpha1.GkmCondError.IsConditionSet(gkmCacheStatus.Conditions) {
-					r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondError.Condition())
-					reason = "Set Error Condition"
-				}
-			} else if gkmCacheStatus.Counts.PodOutdatedCnt != 0 {
-				if !gkmv1alpha1.GkmCondOutdated.IsConditionSet(gkmCacheStatus.Conditions) {
-					r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondOutdated.Condition())
-					reason = "Set Outdated Condition"
-				}
-			} else if gkmCacheStatus.Counts.NodeInUseCnt != 0 {
-				if !gkmv1alpha1.GkmCondRunning.IsConditionSet(gkmCacheStatus.Conditions) {
-					r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondRunning.Condition())
-					reason = "Set Running Condition"
-				}
-			} else if gkmCacheStatus.Counts.NodeNotInUseCnt != 0 {
-				if !gkmv1alpha1.GkmCondExtracted.IsConditionSet(gkmCacheStatus.Conditions) {
-					r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondExtracted.Condition())
-					reason = "Set Extracted Condition"
-				}
-			}
-
-			if !reflect.DeepEqual(gkmCache.GetStatus(), gkmCacheStatus) {
-				gkmCacheStatus.LastUpdated = metav1.Now()
-
-				if err := reconciler.cacheUpdateStatus(ctx, &gkmCache, gkmCacheStatus, reason); err != nil {
-					errorHit = true
-					continue
-				} else {
-					// GKMCache Object was updated successfully.
-					// Return and Reconcile will be retriggered with the GKMCache Object.
-					return ctrl.Result{Requeue: false}, nil
-				}
-			}
-		} else {
-			if gkmCacheStatus.Counts.NodeCnt == 0 {
-				// Everything should be cleaned up, so delete the GKMCacheNode specific
-				// finalizer from the GKMCache.
-				changed, err := reconciler.cacheRemoveFinalizer(ctx, &gkmCache)
+			if !cacheDeleting {
+				// Add Finalizer to GKMCache or ClusterGKMCache if not there. This is a KubeAPI call,
+				// so return if finalizer needed to be added.
+				changed, err := reconciler.cacheAddFinalizer(ctx, &gkmCache)
 				if err != nil {
 					errorHit = true
 					continue
@@ -426,14 +208,293 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) reconcileCommonOperator(
 					// GKMCache object was updated. Return and change will retrigger a new reconcile.
 					return ctrl.Result{Requeue: false}, nil
 				}
+			}
+
+			gkmCacheStatus := gkmCache.GetStatus()
+			gkmCacheStatus.Counts = gkmv1alpha1.CacheCounts{}
+			gkmCacheStatus.ResolvedDigest = resolvedDigest
+
+			if gkmCacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerUnknown || gkmCacheStatus.PvcOwner == "" {
+				// Initialize the condition to pending.
+				r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondPending.Condition())
+
+				gkmCacheStatus.PvcOwner = gkmv1alpha1.PvcOwnerAgent
+				accessMode := gkmCache.GetAccessMode()
+				for _, mode := range accessMode {
+					if mode == corev1.ReadOnlyMany {
+						gkmCacheStatus.PvcOwner = gkmv1alpha1.PvcOwnerOperator
+					}
+				}
+				r.Logger.Info("Owner not set, setting now", "Updated Value", gkmCacheStatus.PvcOwner)
+			}
+
+			// If the PVC AccessMode is ReadOnlyMany, then only one PVC per Namespace needs to be created
+			// and the storage backend will handle propagating the extracted cache to each node. Since
+			// there is only one, the Operator handles the creation here.
+			if gkmCacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerOperator {
+				updated := false
+				updateReason := ""
+
+				// Loop through the list of Namespaces. For GKMCache, it's just the namespace
+				// GKMCache is created in. For ClusterGKMCache, it's the Workload Namespace list
+				// that was provided in ClusterGKMCache.
+				namespaceList := gkmCache.GetWorkloadNamespaces()
+				if len(namespaceList) == 0 {
+					if gkmCache.GetNamespace() == "" {
+						r.Logger.Info("No namespaces in ClusterGKMCache Spec.WorkloadNamespaces, so no PVCs created",
+							"Namespace", gkmCache.GetNamespace(),
+							"Name", gkmCache.GetName(),
+						)
+					}
+				}
+				for _, pvcNamespace := range namespaceList {
+					var pvcStatus gkmv1alpha1.PvcStatus
+					skipPvcCopy := false
+
+					namespaceExists, namespaceDeleting, err := r.namespaceExists(ctx, pvcNamespace)
+					if err != nil {
+						errorHit = true
+						continue
+					}
+
+					// CREATE or UPDATE
+					if !cacheDeleting && !namespaceDeleting {
+
+						// Get the PVC Status, which is the Per Namespace PV and PVC information.
+						if gkmCacheStatus.PvcStatus == nil {
+							gkmCacheStatus.PvcStatus = make(map[string]gkmv1alpha1.PvcStatus)
+							updated = true
+							updateReason = "PvcStatus Allocation"
+						}
+
+						var pvcStatusExisted bool
+						pvcStatus, pvcStatusExisted = gkmCacheStatus.PvcStatus[pvcNamespace]
+						if !pvcStatusExisted {
+							pvcStatus = gkmv1alpha1.PvcStatus{}
+							gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondPending.Condition())
+							pvcStatus.PvcOwner = gkmv1alpha1.PvcOwnerOperator
+							updated = true
+							updateReason = "PvcStatus Initialization"
+						}
+
+						// Manage PV, PVC and Job used for extracted GPU Kernel Cache
+						if pvcUpdated, pvcUpdateReason, pending, err := r.managePvcStatusModify(
+							ctx,
+							reconciler,
+							&gkmCache,
+							gkmCacheStatus,
+							&pvcStatus,
+							pvcNamespace,
+							resolvedDigest,
+							capacity,
+							namespaceExists,
+						); err != nil {
+							errorHit = true
+							continue
+						} else if pvcUpdated {
+							updated = true
+							updateReason = pvcUpdateReason
+						} else if pending {
+							stillInUse = true
+						}
+					} else {
+						// DELETE
+						pvcInUse := false
+
+						// Get the PVC Status, which is the Per Namespace PV and PVC information.
+						// If it doesn't exist for this Namespace, then move on to the next Namespace.
+						if gkmCacheStatus.PvcStatus == nil {
+							continue
+						}
+
+						var pvcStatusExisted bool
+						pvcStatus, pvcStatusExisted = gkmCacheStatus.PvcStatus[pvcNamespace]
+						if !pvcStatusExisted {
+							continue
+						}
+
+						var pvcDeleting bool
+						if updated, updateReason, pvcInUse, pvcDeleting, err = common.ManagePvcStatusDelete(
+							ctx,
+							r.Client,
+							gkmCache.GetNamespace(),
+							gkmCache.GetName(),
+							"", // NodeName
+							&pvcStatus,
+							gkmv1alpha1.PvcOwnerOperator,
+							pvcNamespace,
+							resolvedDigest,
+							r.Logger,
+						); err != nil {
+							errorHit = true
+							continue
+						} else if pvcInUse || pvcDeleting {
+							stillInUse = true
+							if !gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+								gkmv1alpha1.SetPvcStatusConditions(&pvcStatus, gkmv1alpha1.GkmCondDeleting.Condition())
+								updated = true
+								updateReason = "Update Condition to Deleting"
+							}
+						}
+
+						// If nothing was updated, then this PVC Status can be removed.
+						if !updated && !pvcInUse {
+							delete(gkmCacheStatus.PvcStatus, pvcNamespace)
+							updated = true
+							skipPvcCopy = true
+							updateReason = "Remove PVC Namespace entry"
+						}
+					}
+
+					if updated {
+						if !skipPvcCopy {
+							// Update the Cache Status copy of the PVC Status before writing the data below.
+							gkmCacheStatus.PvcStatus[pvcNamespace] = pvcStatus
+						}
+						break
+					}
+				} // For each Namespace
+
+				// Call KubeAPI to update the Status for the GKMCache (or ClusterGKMCache) that was
+				// modified above.
+				if updated {
+					gkmCacheStatus.LastUpdated = metav1.Now()
+					changed, err := reconciler.cacheUpdateStatus(ctx, &gkmCache, gkmCacheStatus, updateReason)
+					if err != nil {
+						errorHit = true
+						continue
+					} else {
+						// GKMCache Object was updated successfully.
+						// Return and Reconcile will be retriggered with the GKMCache Object.
+						r.Logger.V(1).Info("Return after CacheStatus Write", "Reason", updateReason, "changed", changed)
+						if changed {
+							return ctrl.Result{Requeue: false}, nil
+						} else {
+							return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
+						}
+					}
+				}
+			}
+
+			// Call KubeAPI to Retrieve the list of GKMCacheNodes for this Namespace.
+			// Should be one per Node if GKMCache was created in the Namespace.
+			opts := []client.ListOption{
+				client.InNamespace(gkmCache.GetNamespace()),
+			}
+			gkmCacheNodeList, err := reconciler.getCacheNodeList(ctx, opts)
+			if err != nil {
+				// Error returned if unable to call KubeAPI. Don't block Reconcile on one instance,
+				// log and go to next GKMCache.
+				r.Logger.Error(err, "failed to get GKMCacheNode List", "Namespace", gkmCache.GetNamespace(), "Name", gkmCache.GetName())
+				errorHit = true
+				continue
+			}
+
+			// Loop through each GKMCacheNode (i.e. each Node)
+			for _, gkmCacheNode := range (*gkmCacheNodeList).GetItems() {
+				nodeStatus := gkmCacheNode.GetStatus()
+				if nodeStatus != nil {
+					// See if this GKMCache has been added to the GKMCacheNode
+					if _, ok := nodeStatus.CacheStatuses[gkmCache.GetName()]; ok {
+						// This Cache was found in a GKMCacheNode instance
+						gkmCacheStatus.Counts.NodeCnt += nodeStatus.Counts.NodeCnt
+						gkmCacheStatus.Counts.NodeInUseCnt += nodeStatus.Counts.NodeInUseCnt
+						gkmCacheStatus.Counts.NodeNotInUseCnt += nodeStatus.Counts.NodeNotInUseCnt
+						gkmCacheStatus.Counts.NodeErrorCnt += nodeStatus.Counts.NodeErrorCnt
+						gkmCacheStatus.Counts.PodRunningCnt += nodeStatus.Counts.PodRunningCnt
+						gkmCacheStatus.Counts.PodDeletingCnt += nodeStatus.Counts.PodDeletingCnt
+						gkmCacheStatus.Counts.PodOutdatedCnt += nodeStatus.Counts.PodOutdatedCnt
+					}
+				}
+			}
+
+			r.Logger.V(1).Info("Processed GKMCache",
+				"Namespace", gkmCache.GetNamespace(),
+				"CacheName", gkmCache.GetName(),
+				"NodeCnt", gkmCacheStatus.Counts.NodeCnt,
+				"NodeInUse", gkmCacheStatus.Counts.NodeInUseCnt,
+				"NodeNotInUse", gkmCacheStatus.Counts.NodeNotInUseCnt,
+				"NodeError", gkmCacheStatus.Counts.NodeErrorCnt,
+				"PodRunning", gkmCacheStatus.Counts.PodRunningCnt,
+				"PodDeleting", gkmCacheStatus.Counts.PodDeletingCnt,
+				"PodOutdated", gkmCacheStatus.Counts.PodOutdatedCnt,
+				"Conditions", gkmCacheStatus.Conditions,
+			)
+
+			if !cacheDeleting {
+				reason := "Update Counts"
+				// Adjust Condition if need. If Operator owns the PVC extraction, then
+				// wait for Pending and Downloading state to clear before adjusting based
+				// on GKMCacheNode or ClusterGKMCacheNode counts.
+				if gkmCacheStatus.Counts.NodeErrorCnt != 0 {
+					if !gkmv1alpha1.GkmCondError.IsConditionSet(gkmCacheStatus.Conditions) {
+						r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondError.Condition())
+						reason = "Set Error Condition"
+					}
+				} else if gkmCacheStatus.Counts.PodOutdatedCnt != 0 {
+					if !gkmv1alpha1.GkmCondOutdated.IsConditionSet(gkmCacheStatus.Conditions) {
+						r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondOutdated.Condition())
+						reason = "Set Outdated Condition"
+					}
+				} else if gkmCacheStatus.Counts.NodeInUseCnt != 0 {
+					if !gkmv1alpha1.GkmCondRunning.IsConditionSet(gkmCacheStatus.Conditions) {
+						r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondRunning.Condition())
+						reason = "Set Running Condition"
+					}
+				} else if gkmCacheStatus.Counts.NodeNotInUseCnt != 0 {
+					if !gkmv1alpha1.GkmCondExtracted.IsConditionSet(gkmCacheStatus.Conditions) {
+						r.setCacheConditions(gkmCacheStatus, gkmv1alpha1.GkmCondExtracted.Condition())
+						reason = "Set Extracted Condition"
+					}
+				}
+
+				if !reflect.DeepEqual(gkmCache.GetStatus(), gkmCacheStatus) {
+					gkmCacheStatus.LastUpdated = metav1.Now()
+
+					if changed, err := reconciler.cacheUpdateStatus(ctx, &gkmCache, gkmCacheStatus, reason); err != nil {
+						errorHit = true
+						continue
+					} else {
+						// GKMCache Object was updated successfully.
+						// Return and Reconcile will be retriggered with the GKMCache Object.
+						r.Logger.V(1).Info("Return after CacheStatus Write", "Reason", reason, "changed", changed)
+						if changed {
+							return ctrl.Result{Requeue: false}, nil
+						} else {
+							return ctrl.Result{Requeue: true, RequeueAfter: utils.RetryAgentNodeStatusUpdate}, nil
+						}
+					}
+				}
 			} else {
-				r.Logger.Info("Deleting GKMCache still in progress",
-					"Namespace", gkmCache.GetNamespace(),
-					"CacheName", gkmCache.GetName(),
-					"Pending", gkmCacheStatus.Counts.NodeCnt,
-				)
+				if gkmCacheStatus.Counts.NodeCnt == 0 {
+					// Everything should be cleaned up, so delete the GKMCacheNode specific
+					// finalizer from the GKMCache.
+					changed, err := reconciler.cacheRemoveFinalizer(ctx, &gkmCache)
+					if err != nil {
+						errorHit = true
+						continue
+					} else if changed {
+						// GKMCache object was updated. Return and change will retrigger a new reconcile.
+						return ctrl.Result{Requeue: false}, nil
+					}
+				} else {
+					r.Logger.Info("Deleting GKMCache still in progress",
+						"Namespace", gkmCache.GetNamespace(),
+						"CacheName", gkmCache.GetName(),
+						"Pending", gkmCacheStatus.Counts.NodeCnt,
+					)
+					stillInUse = true
+				}
 			}
 		}
+	}
+
+	// Walk the GKMCacheNode or ClusterGKMCacheNode and determine if any PVCs are stranded.
+	// If so, see if the Pod using them is still active. If not, clean them up.
+	if strandedInUse, strandedErrFlag := r.manageStrandedPvcs(ctx, reconciler, inUseGkmCacheList); strandedErrFlag {
+		errorHit = true
+	} else if strandedInUse {
+		stillInUse = true
 	}
 
 	if errorHit || stillInUse {
@@ -451,6 +512,52 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) setCacheConditions(gkmCacheStat
 	meta.SetStatusCondition(&gkmCacheStatus.Conditions, condition)
 }
 
+// managePvcStatusModify handles Create and Update calls. If necessary, it will handle the creation
+// of a PV, PVC or Job to extract GPU Kernel Cache to the PVC, depending on the state.
+func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePvcStatusModify(
+	ctx context.Context,
+	reconciler OperatorReconciler[C, CL, N, NL],
+	gkmCache *C,
+	gkmCacheStatus *gkmv1alpha1.GKMCacheStatus,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	pvcNamespace string,
+	resolvedDigest string,
+	capacity string,
+	namespaceExists bool,
+) (bool, string, bool, error) {
+	updated := false
+	updateReason := ""
+	pending := false
+	var err error
+
+	// Since Operator owns PV/PVC, manage each now.
+	// If updated is already true, still manage PV and PVCs, because up to this
+	// point, it's just been initialization and allocation of structures, no
+	// actual work on kube objects.
+	if updated, updateReason, err := r.managePVandPVC(
+		ctx,
+		reconciler,
+		gkmCache,
+		gkmCacheStatus,
+		pvcStatus,
+		pvcNamespace,
+		capacity,
+		namespaceExists,
+	); err != nil || updated {
+		return updated, updateReason, pending, err
+	}
+
+	// Launch Job to Extract Cache
+	updated, updateReason, pending, err = r.manageJob(
+		ctx,
+		gkmCache,
+		pvcStatus,
+		pvcNamespace,
+		resolvedDigest,
+	)
+	return updated, updateReason, pending, err
+}
+
 // managePVandPVC manages the PV and PVC that the GPU Kernel Cache is extracted to. If PVC does not exist, then
 // this function calls KubeAPI to create the PVC. It MAY need to create the PV first. If both are created, this
 // function determines if the PVC is in a valid state to receive the extracted GPU Kernel Cache.
@@ -458,32 +565,49 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePVandPVC(
 	ctx context.Context,
 	reconciler OperatorReconciler[C, CL, N, NL],
 	gkmCache *C,
-	cacheStatus *gkmv1alpha1.GKMCacheStatus,
+	gkmCacheStatus *gkmv1alpha1.GKMCacheStatus,
 	pvcStatus *gkmv1alpha1.PvcStatus,
 	pvcNamespace string,
 	capacity string,
+	namespaceExists bool,
 ) (bool, string, error) {
 	updated := false
 	updateReason := ""
 	pvCreated := false
 
+	if gkmv1alpha1.GkmCondNoNamespace.IsConditionSet(pvcStatus.Conditions) {
+		if namespaceExists {
+			r.Logger.Info("Clearing Condition from No Namespace to Pending")
+			gkmv1alpha1.SetPvcStatusConditions(pvcStatus, gkmv1alpha1.GkmCondPending.Condition())
+			updated = true
+			updateReason = "Update Condition to Pending from No Namespace"
+		}
+	}
+
 	// If the condition on the PVC Status is Pending, then a Job to extract the cache has not been
 	// launched for this Namespace. Make sure the PV and PVC are in a valid state to handle the extraction.
 	if gkmv1alpha1.GkmCondPending.IsConditionSet(pvcStatus.Conditions) {
 		r.Logger.Info("Condition is Pending so managing PV/PVC")
-		if cacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerOperator {
+		if gkmCacheStatus.PvcOwner == gkmv1alpha1.PvcOwnerOperator {
+			if !namespaceExists {
+				gkmv1alpha1.SetPvcStatusConditions(pvcStatus, gkmv1alpha1.GkmCondNoNamespace.Condition())
+				updated = true
+				updateReason = "Update Condition to No Namespace"
+				return updated, updateReason, nil
+			}
+
 			// The preferred method for creating a PV is to create the PVC and Kubelet auto-creates the PV.
 			// In a KIND cluster, there is not a true CSI driver for storage management, so the PV must be
 			// manually created.
 			if r.NoGpu {
-				found, updatedName, err := common.PvExists(
+				_, found, updatedName, err := common.PvExists(
 					ctx,
 					r.Client,
 					(*gkmCache).GetName(),
 					"", // NodeName
 					pvcStatus.PvName,
 					pvcNamespace,
-					cacheStatus.ResolvedDigest,
+					gkmCacheStatus.ResolvedDigest,
 					r.Logger,
 				)
 				if err != nil {
@@ -496,7 +620,6 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePVandPVC(
 				} else if !found {
 					// Call KubeAPI to create the PV.
 					pvcStatus.PvName = utils.GenerateUniqueName((*gkmCache).GetName())
-					r.Logger.Info("BILLY: Generated PV Name", "Name", pvcStatus.PvName)
 
 					accessModes := []corev1.PersistentVolumeAccessMode{
 						corev1.ReadWriteMany,
@@ -515,7 +638,7 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePVandPVC(
 						accessModes,
 						(*gkmCache).GetStorageClassName(),
 						capacity,
-						cacheStatus.ResolvedDigest,
+						gkmCacheStatus.ResolvedDigest,
 						r.Logger,
 					)
 
@@ -531,14 +654,14 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePVandPVC(
 
 			// If PV was not written above, then determine if PVC needs to be created.
 			if !pvCreated {
-				found, updatedName, err := common.PvcExists(
+				_ /* pvc */, found, updatedName, err := common.PvcExists(
 					ctx,
 					r.Client,
 					(*gkmCache).GetName(),
 					"", // NodeName
 					pvcStatus.PvcName,
 					pvcNamespace,
-					cacheStatus.ResolvedDigest,
+					gkmCacheStatus.ResolvedDigest,
 					r.Logger,
 				)
 				if err != nil {
@@ -574,7 +697,7 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) managePVandPVC(
 						accessModes,
 						(*gkmCache).GetStorageClassName(),
 						capacity,
-						cacheStatus.ResolvedDigest,
+						gkmCacheStatus.ResolvedDigest,
 						r.Logger,
 					)
 
@@ -601,9 +724,9 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageJob(
 	pvcStatus *gkmv1alpha1.PvcStatus,
 	jobNamespace string,
 	resolvedDigest string,
-) (bool, bool, string, error) {
-	updateReason := ""
+) (bool, string, bool, error) {
 	updated := false
+	updateReason := ""
 	stillPending := false
 	var err error
 
@@ -638,9 +761,9 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageJob(
 			"", // NodeName
 			(*gkmCache).GetImage(),
 			resolvedDigest,
-			pvcStatus.PvcName,
 			r.NoGpu,
 			r.ExtractImage,
+			pvcStatus,
 			(*gkmCache).GetPodTemplate(),
 			r.Logger,
 		)
@@ -667,8 +790,10 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageJob(
 			r.Logger.V(1).Info("Cache already Extracted",
 				"Object", r.CrdCacheStr,
 				"Namespace", (*gkmCache).GetNamespace(),
-				"Name", (*gkmCache).GetName())
-			return updated, stillPending, updateReason, nil
+				"Name", (*gkmCache).GetName(),
+				"Job Namespace", jobNamespace,
+				"Digest", resolvedDigest)
+			return updated, updateReason, stillPending, nil
 		}
 
 		//latestJob, err := r.getLatestJob(ctx, reconciler, gkmCache)
@@ -681,19 +806,42 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageJob(
 			"", // NodeName
 			r.Logger,
 		)
-		if err != nil {
-			return updated, stillPending, updateReason, err
+		if err != nil || latestJob == nil {
+			r.Logger.Info("Unable to get Latest Job",
+				"Namespace", (*gkmCache).GetNamespace(),
+				"Name", (*gkmCache).GetName(),
+				"Image", (*gkmCache).GetImage(),
+				"PVC Name", pvcStatus.PvcName,
+				"Job Namespace", jobNamespace,
+				"Job Name", pvcStatus.JobName,
+				"err", err,
+			)
+			if latestJob == nil {
+				stillPending = true
+			}
+			return updated, updateReason, stillPending, err
 		}
 
 		r.Logger.Info("Processing Latest Job",
 			"Namespace", (*gkmCache).GetNamespace(),
+			"Job Namespace", jobNamespace,
 			"Name", (*gkmCache).GetName(),
+			"Latest Job Name", latestJob.Name,
 			"Succeeded", latestJob.Status.Succeeded,
 			"Failed", latestJob.Status.Failed,
 			"Active", latestJob.Status.Active,
 			"Ready*", latestJob.Status.Ready,
 			"Conditions", pvcStatus.Conditions,
 		)
+
+		// Job Name is not saved on Create because the an additional hash
+		// is add to requested name. So wait to store the Job name until after
+		// a query.
+		if pvcStatus.JobName != latestJob.Name {
+			pvcStatus.JobName = latestJob.Name
+			updated = true
+			updateReason = "Set Job Name"
+		}
 
 		switch {
 		case latestJob.Status.Succeeded > 0:
@@ -721,5 +869,125 @@ func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageJob(
 		}
 	}
 
-	return updated, stillPending, updateReason, err
+	return updated, updateReason, stillPending, err
+}
+
+// manageStrandedPvcs walks the GKMCacheNode or ClusterGKMCacheNode and determines if any PVCs are
+// stranded (GKMCache or ClusterGKMCache was deleted but Pod was still using PVC). If so, see if the
+// Pod using them is still active. If not, clean them up.
+func (r *ReconcilerCommonOperator[C, CL, N, NL]) manageStrandedPvcs(
+	ctx context.Context,
+	reconciler OperatorReconciler[C, CL, N, NL],
+	inUseGkmCacheList map[string]bool,
+) (bool, bool) {
+	pending := false
+	errorHit := false
+
+	r.Logger.V(1).Info("ENTER manageStrandedPvcs()")
+
+	gkmCacheNodeList, err := reconciler.getCacheNodeList(ctx, []client.ListOption{})
+	if err != nil {
+		errorHit = true
+		return pending, errorHit
+	}
+
+	if (*gkmCacheNodeList).GetItemsLen() == 0 {
+		// KubeAPI doesn't have any GKMCacheNode instances
+		r.Logger.Info("No GKMCacheNode entries found")
+	} else {
+		// There are GKMCacheNode instances created, so loop through each and any check if PVCs are stranded.
+		for _, gkmCacheNode := range (*gkmCacheNodeList).GetItems() {
+			r.Logger.V(1).Info("Verifying Cache Node",
+				"Object", r.CrdCacheStr,
+				"Namespace", gkmCacheNode.GetNamespace(),
+				"Name", gkmCacheNode.GetName(),
+			)
+			nodeStatus := gkmCacheNode.GetStatus()
+			if nodeStatus != nil {
+				for cacheName, digestList := range nodeStatus.CacheStatuses {
+					// Check to see if GKMCache was processed above in main loop. If so, skip over.
+					if _, ok := inUseGkmCacheList[cacheName]; ok {
+						r.Logger.V(1).Info("Skipping Cache because Cache still exists",
+							"Object", r.CrdCacheStr,
+							"Namespace", gkmCacheNode.GetNamespace(),
+							"Name", cacheName,
+						)
+						continue
+					}
+
+					for digest, cacheStatus := range digestList {
+						for namespace, pvcStatus := range cacheStatus.PvcStatus {
+							if pvcStatus.PvcOwner == gkmv1alpha1.PvcOwnerOperator &&
+								gkmv1alpha1.GkmCondDeleting.IsConditionSet(pvcStatus.Conditions) {
+								r.Logger.Info("PVC is in Deleting State",
+									"Object", r.CrdCacheNodeStr,
+									"Name", cacheName,
+									"Digest", digest,
+									"Namespace", namespace,
+									"PVC", pvcStatus.PvcName,
+									"PV", pvcStatus.PvName,
+								)
+								pvcUpdated, pvcUpdateReason, pvcInUse, pvcDeleting, err := common.ManagePvcStatusDelete(
+									ctx,
+									r.Client,
+									namespace,
+									cacheName,
+									"", // NodeName
+									&pvcStatus,
+									gkmv1alpha1.PvcOwnerOperator,
+									namespace,
+									digest,
+									r.Logger,
+								)
+								if err != nil {
+									errorHit = true
+									continue
+								}
+								// This PVC Status is associated with the GKMCacheNode or ClusterGKMCacheNode.
+								// Operator cannot update it. The CacheNode is being used to store the PV and PVC
+								// names. So if something was updated (PVC or PV was deleted), just mark pending so
+								// this code checks again to see if anything needs to be deleted.
+								if pvcUpdated || pvcDeleting {
+									pending = true
+									r.Logger.Info("PVC still In Use or was Updated",
+										"Object", r.CrdCacheNodeStr,
+										"Name", cacheName,
+										"Digest", digest,
+										"Namespace", namespace,
+										"PVC", pvcStatus.PvcName,
+										"PV", pvcStatus.PvName,
+										"Still In Use", pvcInUse,
+										"Deleting", pvcDeleting,
+										"Updated", pvcUpdated,
+										"Reason", pvcUpdateReason,
+									)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return pending, errorHit
+}
+
+func (r *ReconcilerCommonOperator[C, CL, N, NL]) namespaceExists(ctx context.Context, name string) (bool, bool, error) {
+	namespaceExists := false
+	namespaceDeleting := false
+
+	ns := &corev1.Namespace{}
+
+	err := r.Client.Get(ctx, client.ObjectKey{Name: name}, ns)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return namespaceExists, namespaceDeleting, nil
+		}
+		return namespaceExists, namespaceDeleting, err
+	}
+
+	namespaceExists = true
+	namespaceDeleting = !(*ns).GetDeletionTimestamp().IsZero()
+
+	return namespaceExists, namespaceDeleting, nil
 }

--- a/internal/controller/gkm-operator/namespace_gkmcache_controller.go
+++ b/internal/controller/gkm-operator/namespace_gkmcache_controller.go
@@ -20,18 +20,26 @@ package gkmOperator
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gkmv1alpha1 "github.com/redhat-et/GKM/api/v1alpha1"
+	"github.com/redhat-et/GKM/pkg/common"
 	"github.com/redhat-et/GKM/pkg/utils"
 )
 
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gkm.io,resources=gkmcaches,verbs=get;list;watch;create;update;patch;delete
@@ -74,7 +82,29 @@ func (r *GKMCacheOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&gkmv1alpha1.GKMCacheNode{},
 			&handler.EnqueueRequestForObject{},
 		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueGKMCache),
+			builder.WithPredicates(common.PodPredicate("" /* NodeName*/)),
+		).
 		Complete(r)
+}
+
+func (r *GKMCacheOperatorReconciler) enqueueGKMCache(ctx context.Context, obj client.Object) []reconcile.Request {
+	crList := &gkmv1alpha1.GKMCacheList{}
+	if err := r.List(ctx, crList); err != nil || len(crList.Items) == 0 {
+		return nil
+	}
+
+	cr := crList.Items[0]
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name: cr.Name,
+			},
+		},
+	}
 }
 
 // GetCacheList gets the list of GKMCache objects from KubeAPI Server.
@@ -113,33 +143,43 @@ func (r *GKMCacheOperatorReconciler) cacheUpdateStatus(
 	gkmCache *gkmv1alpha1.GKMCache,
 	cacheStatus *gkmv1alpha1.GKMCacheStatus,
 	reason string,
-) error {
-	gkmCache.Status = *cacheStatus.DeepCopy()
+) (bool, error) {
+	changed := true
 
-	r.Logger.Info("Calling KubeAPI to Update GKMCache Status",
-		"reason", reason,
-		"Namespace", gkmCache.Namespace,
-		"CacheName", gkmCache.Name,
-	)
-	if err := r.Status().Update(ctx, gkmCache); err != nil {
-		if strings.Contains(err.Error(), "object has been modified") {
-			r.Logger.Info("failed to update GKMCache Status - outdated",
-				"reason", reason,
-				"Namespace", gkmCache.Namespace,
-				"CacheName", gkmCache.Name,
-				"Error", err,
-			)
-		} else {
-			r.Logger.Error(err, "failed to update GKMCache Status",
-				"reason", reason,
-				"Namespace", gkmCache.Namespace,
-				"CacheName", gkmCache.Name,
-			)
+	if !reflect.DeepEqual(gkmCache.GetStatus(), cacheStatus) {
+		gkmCache.Status = *cacheStatus.DeepCopy()
+
+		r.Logger.Info("Calling KubeAPI to Update GKMCache Status",
+			"reason", reason,
+			"Namespace", gkmCache.Namespace,
+			"CacheName", gkmCache.Name,
+		)
+		if err := r.Status().Update(ctx, gkmCache); err != nil {
+			if strings.Contains(err.Error(), "object has been modified") {
+				r.Logger.Info("failed to update GKMCache Status - outdated",
+					"reason", reason,
+					"Namespace", gkmCache.Namespace,
+					"CacheName", gkmCache.Name,
+					"Error", err,
+				)
+			} else {
+				r.Logger.Error(err, "failed to update GKMCache Status",
+					"reason", reason,
+					"Namespace", gkmCache.Namespace,
+					"CacheName", gkmCache.Name,
+				)
+			}
+			return changed, err
 		}
-		return err
+	} else {
+		changed = false
+		r.Logger.Info("cacheUpdateStatus() called but nothing changed",
+			"reason", reason,
+			"CacheName", gkmCache.Name,
+		)
 	}
 
-	return nil
+	return changed, nil
 }
 
 func (r *GKMCacheOperatorReconciler) isBeingDeleted(gkmCache *gkmv1alpha1.GKMCache) bool {

--- a/internal/webhook/pod_pvc_webhook.go
+++ b/internal/webhook/pod_pvc_webhook.go
@@ -165,7 +165,24 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 				"CacheNodeName", gkmCacheNode.GetName(),
 				"Node", nodeName,
 			)
-			if gkmCacheNode.Status.ResolvedDigest == "" {
+
+			resolvedDigest := ""
+			var cacheStatus gkmv1alpha1.CacheStatus
+			for tmpCacheName, cacheList := range gkmCacheNode.Status.CacheStatuses {
+				if tmpCacheName == cacheName {
+					for digest, tmpCacheStatus := range cacheList {
+						// Use the first Digest found. Structure is setup to support multiple digests,
+						// but there is no way at the moment to add additional digests.
+						// TODO: resolvedDigest should be at a high level in the structure and the GKMCacheNode
+						// only supports one GKMCache.
+						resolvedDigest = digest
+						cacheStatus = tmpCacheStatus
+						break
+					}
+				}
+			}
+
+			if resolvedDigest == "" {
 				podWebhookLog.Info("ResolvedDigest NOT set",
 					"PodName", podName,
 					"Namespace", namespace,
@@ -183,22 +200,8 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 				"CacheName", cacheName,
 				"CacheNodeName", gkmCacheNode.GetName(),
 				"Node", nodeName,
-				"ResolvedDigest", gkmCacheNode.Status.ResolvedDigest,
+				"ResolvedDigest", resolvedDigest,
 			)
-			// Get Namespaced PVC
-			cacheStatus, cacheStatusExisted := gkmCacheNode.Status.CacheStatuses[cacheName][gkmCacheNode.Status.ResolvedDigest]
-			if !cacheStatusExisted {
-				podWebhookLog.Info("Can't get Cache Status",
-					"PodName", podName,
-					"Namespace", namespace,
-					"CacheName", cacheName,
-					"CacheNodeName", gkmCacheNode.GetName(),
-					"Node", nodeName,
-					"ResolvedDigest", gkmCacheNode.Status.ResolvedDigest,
-				)
-				err = fmt.Errorf("Cache not set yet")
-				return "", err
-			}
 
 			pvcStatus, pvcStatusExisted := cacheStatus.PvcStatus[namespace]
 			if !pvcStatusExisted {
@@ -208,7 +211,7 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 					"CacheName", cacheName,
 					"CacheNodeName", gkmCacheNode.GetName(),
 					"Node", nodeName,
-					"ResolvedDigest", gkmCacheNode.Status.ResolvedDigest,
+					"ResolvedDigest", resolvedDigest,
 				)
 				err = fmt.Errorf("PVC Status not set yet")
 				return "", err
@@ -221,7 +224,7 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 					"CacheName", cacheName,
 					"CacheNodeName", gkmCacheNode.GetName(),
 					"Node", nodeName,
-					"ResolvedDigest", gkmCacheNode.Status.ResolvedDigest,
+					"ResolvedDigest", resolvedDigest,
 				)
 				err = fmt.Errorf("PVC Name not set yet")
 				return "", err
@@ -280,7 +283,19 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 				"ClusterCacheNodeName", clusterGkmCacheNode.GetName(),
 				"Node", nodeName,
 			)
-			if clusterGkmCacheNode.Status.ResolvedDigest == "" {
+
+			resolvedDigest := ""
+			var cacheStatus gkmv1alpha1.CacheStatus
+			for tmpCacheName, cacheList := range clusterGkmCacheNode.Status.CacheStatuses {
+				if tmpCacheName == cacheName {
+					for digest, tmpCacheStatus := range cacheList {
+						resolvedDigest = digest
+						cacheStatus = tmpCacheStatus
+					}
+				}
+			}
+
+			if resolvedDigest == "" {
 				podWebhookLog.Info("ResolvedDigest NOT set",
 					"PodName", podName,
 					"Namespace", namespace,
@@ -298,22 +313,8 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 				"ClusterCacheName", cacheName,
 				"ClusterCacheNodeName", clusterGkmCacheNode.GetName(),
 				"Node", nodeName,
-				"ResolvedDigest", clusterGkmCacheNode.Status.ResolvedDigest,
+				"ResolvedDigest", resolvedDigest,
 			)
-			// Get Namespaced PVC
-			cacheStatus, cacheStatusExisted := clusterGkmCacheNode.Status.CacheStatuses[cacheName][clusterGkmCacheNode.Status.ResolvedDigest]
-			if !cacheStatusExisted {
-				podWebhookLog.Info("Can't get Cache Status",
-					"PodName", podName,
-					"Namespace", namespace,
-					"ClusterCacheName", cacheName,
-					"ClusterCacheNodeName", clusterGkmCacheNode.GetName(),
-					"Node", nodeName,
-					"ResolvedDigest", clusterGkmCacheNode.Status.ResolvedDigest,
-				)
-				err = fmt.Errorf("Cache not set yet")
-				return "", err
-			}
 
 			pvcStatus, pvcStatusExisted := cacheStatus.PvcStatus[namespace]
 			if !pvcStatusExisted {
@@ -323,7 +324,7 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 					"ClusterCacheName", cacheName,
 					"ClusterCacheNodeName", clusterGkmCacheNode.GetName(),
 					"Node", nodeName,
-					"ResolvedDigest", clusterGkmCacheNode.Status.ResolvedDigest,
+					"ResolvedDigest", resolvedDigest,
 				)
 				err = fmt.Errorf("PVC Status not set yet")
 				return "", err
@@ -336,7 +337,7 @@ func (m *PodMutator) getPvcName(ctx context.Context, podName, namespace, cacheNa
 					"ClusterCacheName", cacheName,
 					"ClusterCacheNodeName", clusterGkmCacheNode.GetName(),
 					"Node", nodeName,
-					"ResolvedDigest", clusterGkmCacheNode.Status.ResolvedDigest,
+					"ResolvedDigest", resolvedDigest,
 				)
 				err = fmt.Errorf("PVC Name not set yet")
 				return "", err

--- a/pkg/common/k8s.go
+++ b/pkg/common/k8s.go
@@ -8,15 +8,183 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	gkmv1alpha1 "github.com/redhat-et/GKM/api/v1alpha1"
 	"github.com/redhat-et/GKM/pkg/utils"
 )
+
+// Common Predicate function for both GKMCache, GKMCacheNode, GKMCacheNode and ClusterCacheNode. Only reconcile
+// if a pod event if it is mounting a PVC and is change phase (state)
+func PodPredicate(nodeName string) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// At Create, the Node is not known, so skip creates and start
+			// processing at Update when the Node is known.
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			logger := log.Log.WithName("pod-predicate")
+
+			oldPod := e.ObjectOld.(*corev1.Pod)
+			newPod := e.ObjectNew.(*corev1.Pod)
+
+			oldUsing := hasPVC(oldPod) && isActive(oldPod)
+			newUsing := hasPVC(newPod) && isActive(newPod)
+
+			if nodeName != "" && newPod.Spec.NodeName != nodeName {
+				logger.V(1).Info("Update: NodeName Skip",
+					"Old Phase", oldPod.Status.Phase, "New Phase", newPod.Status.Phase,
+					"Old PVC", hasPVC(oldPod), "New PVC", hasPVC(newPod),
+					"Old Node", newPod.Spec.NodeName, "New Node", newPod.Spec.NodeName, "Node", nodeName,
+				)
+				return false
+			}
+
+			logger.V(1).Info("Update:",
+				"Old Phase", oldPod.Status.Phase, "New Phase", newPod.Status.Phase,
+				"Old PVC", hasPVC(oldPod), "New PVC", hasPVC(newPod),
+				"Old Node", newPod.Spec.NodeName, "New Node", newPod.Spec.NodeName, "Node", nodeName,
+				"rval", oldUsing != newUsing,
+			)
+
+			// Only trigger if usage changed
+			return oldUsing != newUsing
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			pod := e.Object.(*corev1.Pod)
+
+			// Pod deleted → definitely stopped using PVC
+			return pod.Spec.NodeName == nodeName && hasPVC(pod)
+		},
+	}
+}
+
+func hasPVC(pod *corev1.Pod) bool {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.PersistentVolumeClaim != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isActive(pod *corev1.Pod) bool {
+	// Even though Pending could be considered Active, the Pod is created in Pending
+	// phase, so was not getting a transition. So mark Pending as inactive then when
+	// the phase moves to Running it goes Active.
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded, corev1.PodFailed, corev1.PodPending:
+		return false
+	default:
+		return true
+	}
+}
+
+// ManagePvcStatusDelete handles Delete calls. If necessary, it will handle the deletion
+// of the Job used to extract GPU Kernel Cache to the PVC, then delete the PVC (and PV if
+// it was created) if it is not in use. Deletion of GKMCacheNode or ClusterGKMCacheNode
+// will not be held up by the PVC being in use.
+func ManagePvcStatusDelete(
+	ctx context.Context,
+	objClient client.Client,
+	gkmCacheNamespace string,
+	gkmCacheName string,
+	nodeName string,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	caller gkmv1alpha1.PvcOwner,
+	pvcNamespace string,
+	resolvedDigest string,
+	log logr.Logger,
+) (bool, string, bool, bool, error) {
+	updated := false
+	updateReason := ""
+	pvcInUse := false
+	pvcDeleting := false
+	var err error
+
+	// Try to Delete Job.
+	if updated, updateReason, err = DeleteJob(
+		ctx,
+		objClient,
+		pvcNamespace,
+		nodeName,
+		resolvedDigest,
+		pvcStatus,
+		caller,
+		log,
+	); err != nil {
+		log.Info("Error deleting Job",
+			"Namespace", gkmCacheNamespace,
+			"Name", gkmCacheName,
+			"Job Namespace", pvcNamespace,
+			"Job Name", pvcStatus.JobName,
+			"digest", resolvedDigest,
+			"error", err,
+		)
+	} else if updated {
+		return updated, updateReason, pvcInUse, pvcDeleting, err
+	}
+
+	// Try to Delete PVC.
+	if updated, updateReason, pvcInUse, pvcDeleting, err = DeletePvc(
+		ctx,
+		objClient,
+		gkmCacheName,
+		nodeName,
+		pvcNamespace,
+		resolvedDigest,
+		pvcStatus,
+		caller,
+		log,
+	); err != nil {
+		log.Info("Error deleting PVC",
+			"Namespace", gkmCacheNamespace,
+			"Name", gkmCacheName,
+			"PVC Namespace", pvcNamespace,
+			"PVC Name", pvcStatus.PvcName,
+			"digest", resolvedDigest,
+			"error", err,
+		)
+	} else if updated || pvcInUse || pvcDeleting {
+		return updated, updateReason, pvcInUse, pvcDeleting, err
+	}
+
+	// Try to Delete PV.
+	if updated, updateReason, err = DeletePv(
+		ctx,
+		objClient,
+		gkmCacheName,
+		nodeName,
+		pvcNamespace,
+		resolvedDigest,
+		pvcStatus,
+		caller,
+		log,
+	); err != nil {
+		log.Info("Error deleting PV",
+			"Namespace", gkmCacheNamespace,
+			"Name", gkmCacheName,
+			"PVC Namespace", pvcNamespace,
+			"PV Name", pvcStatus.PvName,
+			"digest", resolvedDigest,
+			"error", err,
+		)
+	} else if updated {
+		return updated, updateReason, pvcInUse, pvcDeleting, err
+	}
+
+	return updated, updateReason, pvcInUse, pvcDeleting, err
+}
 
 // CreatePv calls KubeAPI Server to create a PersistentVolume
 func CreatePv(
@@ -83,18 +251,6 @@ func CreatePv(
 		}
 	}
 
-	// PV are Cluster scoped. If ClusterGKMCache, then Controller Reference can be set. If
-	// GKMCache, then no Controller Reference can be set.
-	if gkmCacheNamespace == "" {
-		if err := controllerutil.SetControllerReference(ownerObj, pv, scheme); err != nil {
-			log.Error(err, "Failed to set controller reference on job",
-				"namespace", gkmCacheNamespace,
-				"name", gkmCacheName,
-			)
-			return err
-		}
-	}
-
 	if err := client.Create(ctx, pv); err != nil {
 		log.Error(err, "Failed to create PV.",
 			"namespace", gkmCacheNamespace,
@@ -122,9 +278,10 @@ func PvExists(
 	pvcNamespace string,
 	resolvedDigest string,
 	log logr.Logger,
-) (bool, string, error) {
+) (*corev1.PersistentVolume, bool, string, error) {
 	found := false
 	updatedName := ""
+	var retPv *corev1.PersistentVolume
 
 	if pvName != "" {
 		found = true
@@ -143,7 +300,7 @@ func PvExists(
 				ctx,
 				pvList,
 				client.MatchingLabels(labelSelector)); err != nil {
-			return found, updatedName, nil
+			return retPv, found, updatedName, nil
 		}
 
 		log.Info("PV List",
@@ -159,7 +316,8 @@ func PvExists(
 			// Since pvName is not set, but found the PV on read, then our copy of the GKMCache or
 			// ClusterGKMCache is outdated. Even if we try to keep going, any KubeAPI writes for them
 			// will fail. Mark our copy of cache outdated, signalling an exit from reconcile loop.
-			updatedName = pvList.Items[0].Name
+			retPv = &(pvList.Items[0])
+			updatedName = retPv.Name
 			log.Info("Cache outdated, PV found",
 				"Name", gkmCacheName,
 				"PVC Namespace", pvcNamespace,
@@ -184,11 +342,129 @@ func PvExists(
 
 			// Error case.
 			err := fmt.Errorf("Multiple PVs found")
-			return found, updatedName, err
+			return retPv, found, updatedName, err
 		}
 	}
 
-	return found, updatedName, nil
+	return retPv, found, updatedName, nil
+}
+
+// DeletePv tries to delete PV created by GKM
+func DeletePv(
+	ctx context.Context,
+	objClient client.Client,
+	gkmCacheName string,
+	nodeName string,
+	pvcNamespace string,
+	resolvedDigest string,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	caller gkmv1alpha1.PvcOwner,
+	log logr.Logger,
+) (bool, string, error) {
+	updated := false
+	updateReason := ""
+
+	log.Info("Deleting PV", "PV Name", pvcStatus.PvName)
+
+	var pv *corev1.PersistentVolume
+	if pvcStatus.PvName != "" {
+		// Have a local copy of the PV name so get a copy of the PV object.
+		pv = &corev1.PersistentVolume{}
+		if err := objClient.Get(ctx, types.NamespacedName{
+			Name: pvcStatus.PvName,
+		}, pv); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("PV already deleted, remove stored PV name",
+					"PVC Namespace", pvcNamespace,
+					"PV Name", pvcStatus.PvName,
+					"digest", resolvedDigest,
+				)
+				pvcStatus.PvName = ""
+				updated = true
+				updateReason = "Deleting PV"
+				err = nil
+			} else {
+				log.Info("Error returned getting current PV for delete, continuing",
+					"PVC Namespace", pvcNamespace,
+					"PV Name", pvcStatus.PvName,
+					"digest", resolvedDigest,
+					"error", err,
+				)
+			}
+			return updated, updateReason, err
+		}
+	} else {
+		// Since PV Name is not set in PVC Status, make sure it doesn't exist.
+		var err error
+		if pv, _, _, err = PvExists(
+			ctx,
+			objClient,
+			gkmCacheName,
+			nodeName,
+			pvcStatus.PvName,
+			pvcNamespace,
+			resolvedDigest,
+			log,
+		); err != nil {
+			log.Info("Error returned getting latest PV for delete, continuing",
+				"PVC Namespace", pvcNamespace,
+				"PV Name", pvcStatus.PvName,
+				"digest", resolvedDigest,
+				"error", err,
+			)
+			return updated, updateReason, err
+		} else if pv == nil {
+			log.Info("No latest PV for delete, continuing",
+				"PVC Namespace", pvcNamespace,
+				"PV Name", pvcStatus.PvName,
+				"digest", resolvedDigest,
+			)
+		}
+	}
+
+	// PV was found, so try to delete.
+	if pv != nil {
+		// If deletion already in progress, do nothing
+		if !pv.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.Info("PV delete already in progress",
+				"PVC Namespace", pvcNamespace,
+				"PV Name", pv.Name,
+				"digest", resolvedDigest,
+			)
+		} else {
+			if caller == pvcStatus.PvcOwner {
+				if err := objClient.Delete(
+					ctx,
+					pv,
+				); err != nil {
+					log.Info("Error deleting PV",
+						"PVC Namespace", pvcNamespace,
+						"PV Name", pv.Name,
+						"digest", resolvedDigest,
+						"error", err,
+					)
+					return updated, updateReason, err
+				} else {
+					log.Info("PV deleted",
+						"PVC Namespace", pvcNamespace,
+						"PV Name", pv.Name,
+						"digest", resolvedDigest,
+					)
+					pvcStatus.PvName = ""
+					updated = true
+					updateReason = "Deleting PV"
+				}
+			} else {
+				log.Info("Not owner of PV so skip Delete",
+					"PVC Namespace", pvcNamespace,
+					"PV Name", pv.Name,
+					"digest", resolvedDigest,
+				)
+			}
+		}
+	}
+
+	return updated, updateReason, nil
 }
 
 // CreatePvc calls KubeAPI Server to create a PersistentVolumeClaim
@@ -242,14 +518,6 @@ func CreatePvc(
 		pvc.Spec.VolumeName = pvName
 	}
 
-	if err := controllerutil.SetControllerReference(ownerObj, pvc, scheme); err != nil {
-		log.Error(err, "Failed to set controller reference on job",
-			"namespace", gkmCacheNamespace,
-			"name", gkmCacheName,
-		)
-		return err
-	}
-
 	if err := client.Create(ctx, pvc); err != nil {
 		log.Error(err, "Failed to create PVC.",
 			"namespace", gkmCacheNamespace,
@@ -280,9 +548,10 @@ func PvcExists(
 	pvcNamespace string,
 	resolvedDigest string,
 	log logr.Logger,
-) (bool, string, error) {
+) (*corev1.PersistentVolumeClaim, bool, string, error) {
 	found := false
 	updatedName := ""
+	var retPvc *corev1.PersistentVolumeClaim
 
 	if pvcName != "" {
 		found = true
@@ -301,7 +570,7 @@ func PvcExists(
 				ctx,
 				pvcList,
 				client.MatchingLabels(labelSelector)); err != nil {
-			return found, updatedName, nil
+			return retPvc, found, updatedName, nil
 		}
 
 		log.Info("PVC List",
@@ -317,15 +586,16 @@ func PvcExists(
 			// Since pvcName is not set, but found the PVC on read, then our copy of the GKMCache or
 			// ClusterGKMCache is outdated. Even if we try to keep going, any KubeAPI writes for them
 			// will fail. Mark our copy of cache outdated, signalling an exit from reconcile loop.
-			updatedName = pvcList.Items[0].Name
-			log.Info("Cache outdated, PV found",
+			retPvc = &(pvcList.Items[0])
+			updatedName = retPvc.Name
+			log.Info("Cache outdated, PVC found",
 				"Name", gkmCacheName,
 				"PVC Namespace", pvcNamespace,
 				"PVC Name", pvcName,
 				"UpdatedName", updatedName,
 				"Node", nodeName,
 				"Digest", resolvedDigest,
-				"NumPVs", len(pvcList.Items),
+				"NumPVCs", len(pvcList.Items),
 			)
 		} else if len(pvcList.Items) > 1 {
 			for i, pvc := range pvcList.Items {
@@ -342,14 +612,15 @@ func PvcExists(
 
 			// Error case.
 			err := fmt.Errorf("Multiple PVCs found")
-			return found, updatedName, err
+			return retPvc, found, updatedName, err
 		}
 	}
 
-	return found, updatedName, nil
+	return retPvc, found, updatedName, nil
 }
 
-// PvcExists tries to determine if a particular PVC has already been created.
+// GetPvcUsedByList walks the Pods in the Namespace and tries to determine which
+// Pods are using the given PVC.
 func GetPvcUsedByList(
 	ctx context.Context,
 	objClient client.Client,
@@ -363,9 +634,12 @@ func GetPvcUsedByList(
 	if pvcName != "" {
 		// List all Pods in the same namespace
 		var podList corev1.PodList
+		filters := []client.ListOption{client.InNamespace(pvcNamespace)}
+		if nodeName != "" {
+			filters = append(filters, client.MatchingFields{"spec.nodeName": nodeName})
+		}
 		if err := objClient.List(ctx, &podList,
-			client.InNamespace(pvcNamespace),
-			client.MatchingFields{"spec.nodeName": nodeName},
+			filters...,
 		); err != nil {
 			log.Info("Unable to retrieve Pod List to check PVC usage",
 				"PVC Namespace", pvcNamespace,
@@ -374,7 +648,12 @@ func GetPvcUsedByList(
 			)
 			return podUseCnt
 		}
-
+		log.Info("Retrieve Pod List to check PVC usage",
+			"PVC Namespace", pvcNamespace,
+			"PVC Name", pvcName,
+			"nodeName", nodeName,
+			"NumPods", len(podList.Items),
+		)
 		for _, pod := range podList.Items {
 			for _, vol := range pod.Spec.Volumes {
 				if pod.Status.Phase != corev1.PodSucceeded &&
@@ -385,6 +664,7 @@ func GetPvcUsedByList(
 							"PVC Namespace", pvcNamespace,
 							"PVC Name", pvcName,
 							"Pod", pod.Name,
+							"nodeName", nodeName,
 						)
 						podUseCnt++
 					}
@@ -394,6 +674,155 @@ func GetPvcUsedByList(
 	}
 
 	return podUseCnt
+}
+
+// DeletePvc tries to delete a PVC.
+func DeletePvc(
+	ctx context.Context,
+	objClient client.Client,
+	gkmCacheName string,
+	nodeName string,
+	pvcNamespace string,
+	resolvedDigest string,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	caller gkmv1alpha1.PvcOwner,
+	log logr.Logger,
+) (bool, string, bool, bool, error) {
+	updated := false
+	updateReason := ""
+	pvcInUse := false
+	pvcDeleting := false
+
+	log.Info("Deleting download PVC",
+		"pvcName", pvcStatus.PvcName,
+		"pvName", pvcStatus.PvName,
+		"Owner", pvcStatus.PvcOwner,
+		"Caller", caller,
+	)
+
+	var pvc *corev1.PersistentVolumeClaim
+	if pvcStatus.PvcName != "" {
+		// Have a local copy of the PVC name so get a copy of the PVC object.
+		pvc = &corev1.PersistentVolumeClaim{}
+		if err := objClient.Get(ctx, types.NamespacedName{
+			Name:      pvcStatus.PvcName,
+			Namespace: pvcNamespace,
+		}, pvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("PVC already deleted, remove stored PVC name",
+					"PVC Namespace", pvcNamespace,
+					"PVC Name", pvcStatus.PvcName,
+					"digest", resolvedDigest,
+				)
+				pvcStatus.PvcName = ""
+				updated = true
+				updateReason = "Deleting PVC"
+				err = nil
+			} else {
+				log.Info("Error returned getting current PVC for delete, continuing",
+					"PVC Namespace", pvcNamespace,
+					"PVC Name", pvcStatus.PvcName,
+					"digest", resolvedDigest,
+					"error", err,
+				)
+			}
+			return updated, updateReason, pvcInUse, pvcDeleting, err
+		}
+	} else {
+		// Since PVC Name is not set in PVC Status, make sure it doesn't exist.
+		var err error
+		if pvc, _, _, err = PvcExists(
+			ctx,
+			objClient,
+			gkmCacheName,
+			nodeName,
+			pvcStatus.PvcName,
+			pvcNamespace,
+			resolvedDigest,
+			log,
+		); err != nil {
+			log.Info("Error returned getting latest PVC for delete, continuing",
+				"PVC Namespace", pvcNamespace,
+				"PVC Name", pvcStatus.PvcName,
+				"digest", resolvedDigest,
+				"error", err,
+			)
+			return updated, updateReason, pvcInUse, pvcDeleting, err
+		} else if pvc == nil {
+			log.Info("No latest PVC for delete, continuing",
+				"PVC Namespace", pvcNamespace,
+				"PVC Name", pvcStatus.PvcName,
+				"digest", resolvedDigest,
+			)
+		}
+	}
+
+	// If a PVC was found, then try to delete it if it is not being used.
+	if pvc != nil {
+		// Check to see if PVC is in use.
+		podInUseCnt := GetPvcUsedByList(
+			ctx,
+			objClient,
+			nodeName,
+			pvcNamespace,
+			pvc.Name,
+			log,
+		)
+
+		if podInUseCnt == 0 {
+			// If deletion already in progress, do nothing
+			if !pvc.ObjectMeta.DeletionTimestamp.IsZero() {
+				log.Info("PVC delete already in progress",
+					"PVC Namespace", pvcNamespace,
+					"PVC Name", pvc.Name,
+					"digest", resolvedDigest,
+				)
+				// Deletion already in progress, set the Deleting flag so code will reexamine
+				// PVC in future ReconcileLoop.
+				pvcDeleting = true
+			} else {
+				if caller == pvcStatus.PvcOwner {
+					// PVC is not in use, so Delete.
+					if err := objClient.Delete(
+						ctx,
+						pvc,
+					); err != nil {
+						log.Info("Error deleting PVC",
+							"PVC Namespace", pvcNamespace,
+							"PVC Name", pvc.Name,
+							"digest", resolvedDigest,
+							"error", err,
+						)
+						return updated, updateReason, pvcInUse, pvcDeleting, err
+					} else {
+						log.Info("PVC deleted",
+							"PVC Namespace", pvcNamespace,
+							"PVC Name", pvc.Name,
+							"digest", resolvedDigest,
+						)
+						pvcStatus.PvcName = ""
+						updated = true
+						updateReason = "Deleting PVC"
+					}
+				} else {
+					log.Info("Not owner of PVC so skip Delete",
+						"PVC Namespace", pvcNamespace,
+						"PVC Name", pvc.Name,
+						"digest", resolvedDigest,
+					)
+				}
+			}
+		} else {
+			pvcInUse = true
+			log.Info("PVC still in use, so skipping delete",
+				"PVC Namespace", pvcNamespace,
+				"PVC Name", pvc.Name,
+				"digest", resolvedDigest,
+			)
+		}
+	}
+
+	return updated, updateReason, pvcInUse, pvcDeleting, nil
 }
 
 // LaunchJob launches a Kubernetes Job that is responsible for extracting the GPU Kernel
@@ -408,13 +837,13 @@ func LaunchJob(
 	nodeName string,
 	cacheImage string,
 	resolvedDigest string,
-	pvcName string,
 	noGpu bool,
 	extractImage string,
+	pvcStatus *gkmv1alpha1.PvcStatus,
 	podTemplate *gkmv1alpha1.PodTemplate,
 	log logr.Logger,
 ) error {
-	log.Info("Creating download job", "jobName", jobName, "pvcName", pvcName)
+	log.Info("Creating download job", "jobName", jobName, "pvcName", pvcStatus.PvcName)
 
 	var jobTTLSecondsAfterFinished int32 = utils.JobTTLSeconds
 	var fsGroup int64 = utils.JobFSGroup
@@ -426,7 +855,7 @@ func LaunchJob(
 		ctx,
 		client,
 		jobNamespace,
-		pvcName,
+		pvcStatus.PvcName,
 		resolvedDigest,
 		nodeName,
 		log,
@@ -476,7 +905,7 @@ func LaunchJob(
 			GenerateName: jobName,
 			Namespace:    jobNamespace,
 			Labels: map[string]string{
-				utils.JobExtractLabelPvc:    pvcName,
+				utils.JobExtractLabelPvc:    pvcStatus.PvcName,
 				utils.JobExtractLabelDigest: trimDigest[:utils.MaxLabelValueLength],
 				utils.JobExtractLabelNode:   nodeName,
 			},
@@ -492,7 +921,7 @@ func LaunchJob(
 							Name: utils.JobExtractPvcSourceMountName,
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvcName,
+									ClaimName: pvcStatus.PvcName,
 								},
 							},
 						},
@@ -633,7 +1062,7 @@ func GetLatestJob(
 		return nil, err
 	}
 
-	log.Info("Jobs found",
+	log.Info("List Jobs",
 		"Job Namespace", jobNamespace,
 		"PVC Name", pvcName,
 		"Digest", resolvedDigest,
@@ -647,8 +1076,128 @@ func GetLatestJob(
 				latestJob = &jobList.Items[i]
 			}
 		}
-	} else {
-		err = fmt.Errorf("no jobs found")
 	}
 	return latestJob, err
+}
+
+// DeleteJob launches a Kubernetes Job that is responsible for extracting the GPU Kernel
+// Cache into a PVC.
+func DeleteJob(
+	ctx context.Context,
+	objClient client.Client,
+	jobNamespace string,
+	nodeName string,
+	resolvedDigest string,
+	pvcStatus *gkmv1alpha1.PvcStatus,
+	caller gkmv1alpha1.PvcOwner,
+	log logr.Logger,
+) (bool, string, error) {
+	updated := false
+	updateReason := ""
+
+	log.Info("Deleting download job", "jobName", pvcStatus.JobName, "pvcName", pvcStatus.PvcName)
+
+	var job *batchv1.Job
+	if pvcStatus.JobName != "" {
+		// Have a local copy of the Job name so get a copy of the Job object.
+		job = &batchv1.Job{}
+		if err := objClient.Get(ctx, types.NamespacedName{
+			Name:      pvcStatus.JobName,
+			Namespace: jobNamespace,
+		}, job); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("Job already deleted, remove stored Job name",
+					"Job Namespace", jobNamespace,
+					"Job Name", pvcStatus.JobName,
+					"digest", resolvedDigest,
+				)
+				pvcStatus.JobName = ""
+				updated = true
+				updateReason = "Deleting Job"
+				err = nil
+			} else {
+				log.Info("Error returned getting current Job for delete, continuing",
+					"Job Namespace", jobNamespace,
+					"Job Name", pvcStatus.JobName,
+					"digest", resolvedDigest,
+					"error", err,
+				)
+			}
+			return updated, updateReason, err
+		}
+	} else {
+		// Since JobName is not set in PVC Status, make sure it doesn't exist.
+		var err error
+		if job, err = GetLatestJob(
+			ctx,
+			objClient,
+			jobNamespace,
+			pvcStatus.PvcName,
+			resolvedDigest,
+			nodeName,
+			log,
+		); err != nil {
+			log.Info("Error returned getting latest Job for delete, continuing",
+				"Job Namespace", jobNamespace,
+				"Job Name", pvcStatus.JobName,
+				"digest", resolvedDigest,
+				"error", err,
+			)
+			return updated, updateReason, err
+		} else if job == nil {
+			log.Info("No latest Job for delete, continuing",
+				"Job Namespace", jobNamespace,
+				"Job Name", pvcStatus.JobName,
+				"digest", resolvedDigest,
+			)
+		}
+	}
+
+	// If a Job was found, then delete it.
+	if job != nil {
+		// If deletion already in progress, do nothing
+		if !job.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.Info("Job delete already in progress",
+				"Job Namespace", jobNamespace,
+				"Job Name", job.Name,
+				"digest", resolvedDigest,
+			)
+		} else {
+			if caller == pvcStatus.PvcOwner {
+				// Indicate to delete associated Job Pods first.
+				policy := metav1.DeletePropagationForeground
+
+				if err := objClient.Delete(
+					ctx,
+					job,
+					client.PropagationPolicy(policy),
+				); err != nil {
+					log.Info("Error deleting Job",
+						"Job Namespace", jobNamespace,
+						"Job Name", job.Name,
+						"digest", resolvedDigest,
+						"error", err,
+					)
+					return updated, updateReason, err
+				} else {
+					log.Info("Job deleted",
+						"Job Namespace", jobNamespace,
+						"Job Name", pvcStatus.JobName,
+						"digest", resolvedDigest,
+					)
+					pvcStatus.JobName = ""
+					updated = true
+					updateReason = "Deleting Job"
+				}
+			} else {
+				log.Info("Not owner of Job so skip Delete",
+					"Job Namespace", jobNamespace,
+					"Job Name", job.Name,
+					"digest", resolvedDigest,
+				)
+			}
+		}
+	}
+
+	return updated, updateReason, nil
 }


### PR DESCRIPTION
Since the code rearchitecture to using PVCs, add support for deleting GKMCache and ClusterGKMCache instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Pod-Deleting" status column, new "Deleting"/"NoNamespace" conditions, and per-PVC job name & owner visibility.
  * Pod-to-node indexing at startup for improved resource tracking.
  * Example manifests: signature-format label, updated image tag, added access modes, and switched one example pod to PVC-backed volume.

* **Bug Fixes**
  * Improved stranded-PVC cleanup and namespace-aware PVC/PV/job teardown to reduce orphaned resources.

* **Chores**
  * Operator permissions extended to observe namespaces and pods; undeploy cleanup narrowed to specific example subfolders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->