### PR TITLE
Add the kind-gpu-sim.sh script to hack instead of downloading it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,7 +571,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 UNDEPLOY_SCRIPT ?= $(shell pwd)/hack/undeploy.sh
-KIND_GPU_SIM_SCRIPT_URL := https://raw.githubusercontent.com/maryamtahhan/kind-gpu-sim/refs/heads/main/kind-gpu-sim.sh
+KIND_GPU_SIM_SCRIPT_HACK := $(shell pwd)/hack/kind-gpu-sim.sh
 KIND_GPU_SIM_SCRIPT := $(LOCALBIN)/kind-gpu-sim.sh
 
 ## Tool Versions
@@ -602,12 +602,11 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: kind-gpu-sim-script
-kind-gpu-sim-script: $(KIND_GPU_SIM_SCRIPT) ## Download  kind-gpu-sim-script locally if necessary.
+kind-gpu-sim-script: $(KIND_GPU_SIM_SCRIPT) ## Install kind-gpu-sim-script to bin from hack if necessary
 $(KIND_GPU_SIM_SCRIPT): $(LOCALBIN)
 	if [ ! -f $(KIND_GPU_SIM_SCRIPT) ]; then \
-		echo "Downloading $(KIND_GPU_SIM_SCRIPT)"; \
-		wget -P $(LOCALBIN) $(KIND_GPU_SIM_SCRIPT_URL); \
-		chmod +x $(KIND_GPU_SIM_SCRIPT); \
+		echo "Installing $(KIND_GPU_SIM_SCRIPT) to $(LOCALBIN)"; \
+		install -D -m 0775 -t $(LOCALBIN) $(KIND_GPU_SIM_SCRIPT_HACK); \
 	fi
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,17 @@ CERT_MGR_VERSION = v1.19.4
 # In a KIND Cluster, NO_GPU is true and GPU_TYPE is the simulated GPU type.
 GPU_TYPE ?= rocm
 
+LOCALBIN ?= $(shell pwd)/bin
+## Location to install dependencies to
+$(LOCALBIN):
+	mkdir -p $@
+
+KIND_GPU_SIM_SCRIPT_HACK := $(shell pwd)/hack/kind-gpu-sim.sh
+KIND_GPU_SIM_SCRIPT := $(LOCALBIN)/kind-gpu-sim.sh
+$(KIND_GPU_SIM_SCRIPT): $(KIND_GPU_SIM_SCRIPT_HACK) | $(LOCALBIN)
+	@echo "Installing $(KIND_GPU_SIM_SCRIPT) to $(LOCALBIN)"
+	install -m 0775 $< $@
+
 # This Makefile may use docker, but when running the KIND cluster with a
 # simulated GPU, KIND requires podman. The KIND_GPU_SIM_SCRIPT sets up the
 # following podman environment variables to allow podman with KIND.
@@ -373,7 +384,7 @@ GPU_TYPE ?= rocm
 # export KIND_EXPERIMENTAL_PROVIDER=podman
 # export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
 .PHONY: get-example-images
-get-example-images:
+get-example-images: $(KIND_GPU_SIM_SCRIPT)
 	$(CONTAINER_TOOL) pull quay.io/gkm/cache-examples:vector-add-cache-rocm-v2
 	cat $(KIND_GPU_SIM_SCRIPT) | bash -s load --image-name=quay.io/gkm/cache-examples:vector-add-cache-rocm-v2 --cluster-name=$(KIND_CLUSTER_NAME)
 	$(CONTAINER_TOOL) pull quay.io/gkm/cache-examples:vector-add-cache-rocm
@@ -400,7 +411,7 @@ rotate-webhook-secret:
 	$(KUSTOMIZE) build config/secret | $(KUBECTL) apply -f -
 
 .PHONY: get-cert-manager-images
-get-cert-manager-images: kind-gpu-sim-script
+get-cert-manager-images: $(KIND_GPU_SIM_SCRIPT)
 	@echo "Getting Images ..."
 	$(CONTAINER_TOOL) pull quay.io/jetstack/cert-manager-controller:$(CERT_MGR_VERSION)
 	$(CONTAINER_TOOL) pull quay.io/jetstack/cert-manager-cainjector:$(CERT_MGR_VERSION)
@@ -493,13 +504,13 @@ undeploy-kyverno: ## Undeploy Kyverno
 ##@ Kind Cluster Management
 
 .PHONY: setup-kind
-setup-kind: kind-gpu-sim-script
+setup-kind: $(KIND_GPU_SIM_SCRIPT)
 	@echo "Creating Kind GPU cluster with GPU type: $(GPU_TYPE) and cluster name: $(KIND_CLUSTER_NAME)"
 	cat $(KIND_GPU_SIM_SCRIPT) | bash -s create $(GPU_TYPE) --cluster-name=$(KIND_CLUSTER_NAME)
 	@echo "Kind GPU cluster $(KIND_CLUSTER_NAME) created successfully."
 
 .PHONY: kind-load-images
-kind-load-images: kind-gpu-sim-script get-example-images
+kind-load-images: $(KIND_GPU_SIM_SCRIPT) get-example-images
 	@echo "Loading operator image ${OPERATOR_IMG} into Kind cluster: $(KIND_CLUSTER_NAME)"
 	cat $(KIND_GPU_SIM_SCRIPT) | bash -s load --image-name=${OPERATOR_IMG} --cluster-name=$(KIND_CLUSTER_NAME)
 	@echo "Loading agent image ${AGENT_IMG} into Kind cluster: $(KIND_CLUSTER_NAME)"
@@ -552,17 +563,12 @@ undeploy-on-kind-force: ## Same as "make undeploy-on-kind" but also delete any d
 	$(MAKE) undeploy-on-kind FORCE=--force
 
 .PHONY: destroy-kind
-destroy-kind: kind-gpu-sim-script ## Delete the Kind GPU cluster
+destroy-kind: $(KIND_GPU_SIM_SCRIPT) ## Delete the Kind GPU cluster
 	@echo "Deleting Kind GPU cluster: $(KIND_CLUSTER_NAME)"
 	cat $(KIND_GPU_SIM_SCRIPT) | bash -s delete --cluster-name=$(KIND_CLUSTER_NAME)
 	@echo "Kind GPU cluster $(KIND_CLUSTER_NAME) deleted successfully."
 
 ##@ Dependencies
-
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
 
 ## Tool Binaries
 KUBECTL ?= kubectl
@@ -571,8 +577,6 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 UNDEPLOY_SCRIPT ?= $(shell pwd)/hack/undeploy.sh
-KIND_GPU_SIM_SCRIPT_HACK := $(shell pwd)/hack/kind-gpu-sim.sh
-KIND_GPU_SIM_SCRIPT := $(LOCALBIN)/kind-gpu-sim.sh
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
@@ -600,14 +604,6 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
-
-.PHONY: kind-gpu-sim-script
-kind-gpu-sim-script: $(KIND_GPU_SIM_SCRIPT) ## Install kind-gpu-sim-script to bin from hack if necessary
-$(KIND_GPU_SIM_SCRIPT): $(LOCALBIN)
-	if [ ! -f $(KIND_GPU_SIM_SCRIPT) ]; then \
-		echo "Installing $(KIND_GPU_SIM_SCRIPT) to $(LOCALBIN)"; \
-		install -D -m 0775 -t $(LOCALBIN) $(KIND_GPU_SIM_SCRIPT_HACK); \
-	fi
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -364,15 +364,15 @@ function delete_cluster() {
 
 function delete_registry() {
   echo "Stopping ${REGISTRY_NAME} (if running)..."
-  if cr ps -q -f "name=^/${REGISTRY_NAME}$" &>/dev/null; then
-    cr stop "${REGISTRY_NAME}" || echo "Warning: Failed to stop ${REGISTRY_NAME}"
+  if [ -n "$(cr ps -q -f "name=^/${REGISTRY_NAME}$")" ]; then
+    cr stop "${REGISTRY_NAME}" &>/dev/null || echo "Warning: Failed to stop ${REGISTRY_NAME}"
   else
     echo "No running container named '${REGISTRY_NAME}' to stop."
   fi
 
   echo "Removing ${REGISTRY_NAME} (if exists)..."
-  if cr ps -aq -f "name=^/${REGISTRY_NAME}$" &>/dev/null; then
-    cr rm "${REGISTRY_NAME}" || echo "Warning: Failed to remove ${REGISTRY_NAME}"
+  if [ -n "$(cr ps -aq -f "name=^/${REGISTRY_NAME}$")" ]; then
+    cr rm "${REGISTRY_NAME}" &>/dev/null || echo "Warning: Failed to remove ${REGISTRY_NAME}"
   else
     echo "No container named '${REGISTRY_NAME}' to remove."
   fi

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -1,0 +1,400 @@
+#!/bin/bash
+set -e
+
+REGISTRY_PORT=5000
+ECR_REGISTRY_IMAGE=public.ecr.aws/docker/library/registry:2
+CLUSTER_NAME=kind-gpu-sim
+LOAD_IMAGE_NAME=not-set
+# Detect OS
+OS_TYPE=$(uname -s)
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+  IS_MACOS=true
+else
+  IS_MACOS=false
+fi
+
+if [ "$IS_MACOS" = true ]; then
+  PID_CMD="pgrep"
+else
+  PID_CMD="pidof"
+fi
+
+# Detect the available `sed` tool
+if command -v gsed &>/dev/null; then
+  USE_GSED=true
+  SED=gsed  # Use `gsed` if available
+else
+  USE_GSED=false
+  SED=sed   # Fallback to default `sed`
+fi
+
+for arg in "$@"; do
+  case "$arg" in
+    --registry-port=*)
+      REGISTRY_PORT="${arg#*=}"
+      ;;
+    --cluster-name=*)
+      CLUSTER_NAME="${arg#*=}"
+      ;;
+    --image-name=*)
+      LOAD_IMAGE_NAME="${arg#*=}"
+      ;;
+  esac
+done
+
+# --- Runtime detection ---
+if command -v podman &>/dev/null; then
+  echo "Using Podman as container runtime"
+  CONTAINER_RUNTIME="podman"
+  export KIND_EXPERIMENTAL_PROVIDER=podman
+  export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
+  if [ "$IS_MACOS" = true ]; then
+    echo "Skipping systemctl command as it's not available on macOS"
+  else
+    systemctl --user enable --now podman.socket || true
+  fi
+elif command -v docker &>/dev/null; then
+  echo "Using Docker as container runtime"
+  CONTAINER_RUNTIME="docker"
+else
+  echo "ERROR: Neither Docker nor Podman is installed." >&2
+  exit 1
+fi
+
+cr() {
+  "$CONTAINER_RUNTIME" "$@"
+}
+
+CONFIG_FILE=kind-config.yaml
+REGISTRY_NAME="kind-registry"
+
+function start_local_registry() {
+  echo "Starting local registry on port ${REGISTRY_PORT}..."
+  running=$(cr inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || echo "false")
+  if [ "$running" != "true" ]; then
+    cr run -d --restart=always -p "${REGISTRY_PORT}:5000" \
+      --name "${REGISTRY_NAME}" "${ECR_REGISTRY_IMAGE}"
+  else
+    echo "Registry '${REGISTRY_NAME}' already running."
+  fi
+  echo "Ensuring the registry is connected to the Kind network..."
+  cr network connect kind "${REGISTRY_NAME}" 2>/dev/null || true
+}
+
+function generate_kind_config() {
+  [ -f "${CONFIG_FILE}" ] && rm -f "${CONFIG_FILE}"
+  cat > "${CONFIG_FILE}" <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+      endpoint = ["http://${REGISTRY_NAME}:5000"]
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+EOF
+}
+
+function create_kind_cluster() {
+  gpu_type="$1"
+  generate_kind_config
+  kind create cluster --name "${CLUSTER_NAME}" --config "${CONFIG_FILE}"
+  cr network connect "kind" "${REGISTRY_NAME}" || true
+
+  worker_nodes=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -v control-plane)
+  for node in $worker_nodes; do
+    kubectl label node "$node" hardware-type=gpu --overwrite
+    kubectl label node "$node" node-role.kubernetes.io/worker="" --overwrite
+    kubectl taint node "$node" gpu=true:NoSchedule --overwrite
+    if [ "$gpu_type" = "rocm" ]; then
+      kubectl label node "$node" rocm.amd.com/gpu.present=true --overwrite
+      kubectl patch node "$node" --type=json -p='[{"op": "add", "path": "/status/capacity/amd.com~1gpu", "value":"2"}]' --subresource=status
+    elif [ "$gpu_type" = "nvidia" ]; then
+      kubectl label node "$node" nvidia.com/gpu.present=true --overwrite
+      kubectl patch node "$node" --type=json -p='[{"op": "add", "path": "/status/capacity/nvidia.com~1gpu", "value":"2"}]' --subresource=status
+    fi
+  done
+
+  for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
+    cr exec "$node" mkdir -p "/etc/containerd/certs.d/localhost:${REGISTRY_PORT}"
+    cat <<EOF | cr exec -i "$node" tee "/etc/containerd/certs.d/localhost:${REGISTRY_PORT}/hosts.toml" >/dev/null
+[host."http://${REGISTRY_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+    cr exec "$node" kill -SIGHUP $($PID_CMD containerd) 2>/dev/null || echo "Warning: could not reload containerd on $node"
+  done
+}
+
+function apply_local_registry_configmap() {
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+}
+
+# Patching Dockerfile based on the GPU type (rocm or nvidia)
+patch_dockerfile() {
+  gpu_type="$1"
+  echo "Patching Dockerfile for $gpu_type compatibility..."
+  # Additional GPU-specific changes
+  if [ "$gpu_type" = "nvidia" ]; then
+    # Apply NVIDIA-specific patching if needed
+    echo "Applying NVIDIA-specific patches to the Dockerfile..."
+      if [ "$IS_MACOS" = true ] && [ "$USE_GSED" = false ]; then
+        # macOS-specific patching with sed
+        ${SED} -i '' 's|^FROM redhat/ubi9-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+        ${SED} -i '' 's|^FROM public.ecr.aws/ubi9/ubi-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+        ${SED} -i '' 's|^FROM registry.access.redhat.com/ubi9/ubi9-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+      else
+        # Linux-specific patching with default sed
+        ${SED} -i 's|^FROM redhat/ubi9-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+        ${SED} -i 's|^FROM public.ecr.aws/ubi9/ubi-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+        ${SED} -i 's|^FROM registry.access.redhat.com/ubi9/ubi9-minimal|FROM registry.access.redhat.com/ubi9/ubi-minimal|' deployments/container/Dockerfile
+      fi
+  elif [ "$gpu_type" = "rocm" ]; then
+    # Apply ROCm-specific patching if needed
+    echo "Applying ROCm-specific patches to the Dockerfile..."
+    if [ "$IS_MACOS" = true ] && [ "$USE_GSED" = false ]; then
+      # macOS-specific patching with sed
+      ${SED} -i '' "s|^FROM alpine:3.21.3|FROM public.ecr.aws/docker/library/alpine:3.21.3|" Dockerfile
+      ${SED} -i '' "s|^FROM docker.io/golang:1.23.6-alpine3.21|FROM public.ecr.aws/docker/library/golang:1.23.6-alpine3.21|" Dockerfile
+      ${SED} -i '' "s|^FROM golang:1.23.6-alpine3.21|FROM public.ecr.aws/docker/library/golang:1.23.6-alpine3.21|" Dockerfile
+    else
+      # Linux-specific patching with default sed
+      ${SED} -i "s|^FROM alpine:3.21.3|FROM public.ecr.aws/docker/library/alpine:3.21.3|" Dockerfile
+      ${SED} -i "s|^FROM docker.io/golang:1.23.6-alpine3.21|FROM public.ecr.aws/docker/library/golang:1.23.6-alpine3.21|" Dockerfile
+      ${SED} -i "s|^FROM golang:1.23.6-alpine3.21|FROM public.ecr.aws/docker/library/golang:1.23.6-alpine3.21|" Dockerfile
+    fi
+  fi
+}
+
+function build_and_push_images() {
+  gpu_type="$1"
+
+  if [ "$gpu_type" = "nvidia" ]; then
+    echo " Building NVIDIA device plugin locally..."
+    [ ! -d k8s-device-plugin-nvidia ] && git clone https://github.com/NVIDIA/k8s-device-plugin.git k8s-device-plugin-nvidia
+    cd k8s-device-plugin-nvidia
+    git checkout v0.18.2
+
+    if [ "$CONTAINER_RUNTIME" = "podman" ]; then
+      patch_dockerfile "$gpu_type"
+      grep FROM deployments/container/Dockerfile
+      BUILDAH_FORMAT=docker cr build \
+      -t localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev \
+      -f deployments/container/Dockerfile .
+      cr tag localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev localhost/nvidia-device-plugin:dev
+      cr save localhost/nvidia-device-plugin:dev -o /tmp/image.tar
+      kind load image-archive /tmp/image.tar --name "$CLUSTER_NAME"
+      rm -f /tmp/image.tar
+    else
+      cr build \
+        -t localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev \
+        -f deployments/container/Dockerfile .
+      cr push localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev
+
+    fi
+
+    cd ..
+    return
+  fi
+
+  echo " Building ROCm plugin images locally..."
+  [ ! -d k8s-device-plugin-rocm ] && git clone https://github.com/RadeonOpenCompute/k8s-device-plugin.git k8s-device-plugin-rocm
+  cd k8s-device-plugin-rocm
+
+  patch_dockerfile "$gpu_type"
+
+  cr build -t localhost:${REGISTRY_PORT}/amdgpu-dp:dev -f Dockerfile .
+
+  if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    cr push localhost:${REGISTRY_PORT}/amdgpu-dp:dev
+  else
+    cr tag localhost:${REGISTRY_PORT}/amdgpu-dp:dev localhost/amdgpu-dp:dev
+    cr save localhost/amdgpu-dp:dev -o /tmp/image.tar
+    kind load image-archive /tmp/image.tar --name "$CLUSTER_NAME"
+    rm -f /tmp/image.tar
+  fi
+  cd ..
+}
+
+function deploy_device_plugin() {
+  gpu_type="$1"
+  if [ "$gpu_type" = "rocm" ]; then
+    deploy_rocm_plugin
+  elif [ "$gpu_type" = "nvidia" ]; then
+    deploy_nvidia_plugin
+  else
+    echo " Unknown GPU type: $gpu_type"
+    exit 1
+  fi
+}
+
+function deploy_rocm_plugin() {
+  IMAGE_URL="localhost:${REGISTRY_PORT}/amdgpu-dp:dev"
+  if [ "$CONTAINER_RUNTIME" = "podman" ]; then
+    IMAGE_URL="localhost/amdgpu-dp:dev"
+  fi
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: amdgpu-device-plugin
+  template:
+    metadata:
+      labels:
+        app: amdgpu-device-plugin
+    spec:
+      nodeSelector:
+        hardware-type: gpu
+      tolerations:
+        - key: gpu
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      containers:
+        - name: amdgpu-dp-ds
+          image: ${IMAGE_URL}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+EOF
+
+  sleep 5
+  kubectl wait --for=condition=Ready -n kube-system pod -l app=amdgpu-device-plugin --timeout=60s || {
+    echo >&2 "ERROR: ROCm plugin pods not ready in time"
+    exit 1
+  }
+}
+
+function deploy_nvidia_plugin() {
+  IMAGE_URL="localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev"
+  if [ "$CONTAINER_RUNTIME" = "podman" ]; then
+    IMAGE_URL="localhost/nvidia-device-plugin:dev"
+  fi
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-device-plugin
+  template:
+    metadata:
+      labels:
+        app: nvidia-device-plugin
+    spec:
+      nodeSelector:
+        hardware-type: gpu
+      tolerations:
+        - key: gpu
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      containers:
+        - name: nvidia-device-plugin-ctr
+          image: ${IMAGE_URL}
+          securityContext:
+            privileged: true
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
+EOF
+
+  sleep 5
+  kubectl wait --for=condition=Ready -n kube-system pod -l app=nvidia-device-plugin --timeout=60s || {
+    echo >&2 "ERROR: NVIDIA plugin pods not ready in time"
+    exit 1
+  }
+}
+
+function delete_cluster() {
+  if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+    echo "Deleting kind cluster '${CLUSTER_NAME}'..."
+    kind delete cluster --name "${CLUSTER_NAME}"
+  else
+    echo "Kind cluster '${CLUSTER_NAME}' does not exist. Skipping delete."
+  fi
+}
+
+function delete_registry() {
+  echo "Stopping ${REGISTRY_NAME} (if running)..."
+  if cr ps -q -f "name=^/${REGISTRY_NAME}$" &>/dev/null; then
+    cr stop "${REGISTRY_NAME}" || echo "Warning: Failed to stop ${REGISTRY_NAME}"
+  else
+    echo "No running container named '${REGISTRY_NAME}' to stop."
+  fi
+
+  echo "Removing ${REGISTRY_NAME} (if exists)..."
+  if cr ps -aq -f "name=^/${REGISTRY_NAME}$" &>/dev/null; then
+    cr rm "${REGISTRY_NAME}" || echo "Warning: Failed to remove ${REGISTRY_NAME}"
+  else
+    echo "No container named '${REGISTRY_NAME}' to remove."
+  fi
+}
+
+
+function usage() {
+  echo "Usage: $0 {create [rocm|nvidia]|delete|load}"
+  exit 1
+}
+
+function load_image() {
+  if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+    echo "Running: load docker-image ${LOAD_IMAGE_NAME} --name ${CLUSTER_NAME}"
+    kind load docker-image "${LOAD_IMAGE_NAME}" --name "${CLUSTER_NAME}"
+  else
+    cr save ${LOAD_IMAGE_NAME} -o /tmp/image.tar
+    kind load image-archive /tmp/image.tar --name "${CLUSTER_NAME}"
+    rm -f /tmp/image.tar
+  fi
+}
+
+case "$1" in
+  create)
+    gpu_type=${2:-rocm}
+    start_local_registry
+    create_kind_cluster "$gpu_type"
+    apply_local_registry_configmap
+    build_and_push_images "$gpu_type"
+    deploy_device_plugin "$gpu_type"
+    echo " Simulated GPU Kind cluster is ready for '${gpu_type}'!"
+    ;;
+  delete)
+    delete_cluster
+    delete_registry
+    ;;
+  load)
+    load_image
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -88,8 +88,8 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
   - |
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
-      endpoint = ["http://${REGISTRY_NAME}:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
   - role: worker

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -275,11 +275,18 @@ spec:
             privileged: true
 EOF
 
-  sleep 5
-  kubectl wait --for=condition=Ready -n kube-system pod -l app=amdgpu-device-plugin --timeout=60s || {
-    echo >&2 "ERROR: ROCm plugin pods not ready in time"
-    exit 1
-  }
+  retry=3
+  until kubectl wait --for=condition=Ready -n kube-system pod -l app=amdgpu-device-plugin --timeout=60s; do
+    if [[ $retry -eq 0 ]]; then
+      echo >&2 "ERROR: ROCm plugin pods not ready in time"
+      exit 1
+    else
+      ((retry--))
+    fi
+
+    echo "Waiting for pod amdgpu-device-plugin to be ready ..."
+    sleep 5
+  done
 }
 
 function deploy_nvidia_plugin() {

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -22,10 +22,10 @@ fi
 # Detect the available `sed` tool
 if command -v gsed &>/dev/null; then
   USE_GSED=true
-  SED=gsed  # Use `gsed` if available
+  SED="gsed"  # Use `gsed` if available
 else
   USE_GSED=false
-  SED=sed   # Fallback to default `sed`
+  SED="sed"   # Fallback to default `sed`
 fi
 
 for arg in "$@"; do
@@ -190,17 +190,17 @@ function build_and_push_images() {
       patch_dockerfile "$gpu_type"
       grep FROM deployments/container/Dockerfile
       BUILDAH_FORMAT=docker cr build \
-      -t localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev \
+      -t "localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev" \
       -f deployments/container/Dockerfile .
-      cr tag localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev localhost/nvidia-device-plugin:dev
+      cr tag "localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev" localhost/nvidia-device-plugin:dev
       cr save localhost/nvidia-device-plugin:dev -o /tmp/image.tar
       kind load image-archive /tmp/image.tar --name "$CLUSTER_NAME"
       rm -f /tmp/image.tar
     else
       cr build \
-        -t localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev \
+        -t "localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev" \
         -f deployments/container/Dockerfile .
-      cr push localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev
+      cr push "localhost:${REGISTRY_PORT}/nvidia-device-plugin:dev"
 
     fi
 
@@ -214,12 +214,12 @@ function build_and_push_images() {
 
   patch_dockerfile "$gpu_type"
 
-  cr build -t localhost:${REGISTRY_PORT}/amdgpu-dp:dev -f Dockerfile .
+  cr build -t "localhost:${REGISTRY_PORT}/amdgpu-dp:dev" -f Dockerfile .
 
   if [ "$CONTAINER_RUNTIME" = "docker" ]; then
-    cr push localhost:${REGISTRY_PORT}/amdgpu-dp:dev
+    cr push "localhost:${REGISTRY_PORT}/amdgpu-dp:dev"
   else
-    cr tag localhost:${REGISTRY_PORT}/amdgpu-dp:dev localhost/amdgpu-dp:dev
+    cr tag "localhost:${REGISTRY_PORT}/amdgpu-dp:dev" localhost/amdgpu-dp:dev
     cr save localhost/amdgpu-dp:dev -o /tmp/image.tar
     kind load image-archive /tmp/image.tar --name "$CLUSTER_NAME"
     rm -f /tmp/image.tar
@@ -371,7 +371,7 @@ function load_image() {
     echo "Running: load docker-image ${LOAD_IMAGE_NAME} --name ${CLUSTER_NAME}"
     kind load docker-image "${LOAD_IMAGE_NAME}" --name "${CLUSTER_NAME}"
   else
-    cr save ${LOAD_IMAGE_NAME} -o /tmp/image.tar
+    cr save "${LOAD_IMAGE_NAME}" -o /tmp/image.tar
     kind load image-archive /tmp/image.tar --name "${CLUSTER_NAME}"
     rm -f /tmp/image.tar
   fi

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -273,6 +273,14 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
 EOF
 
   retry=3

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 REGISTRY_PORT=5000
 ECR_REGISTRY_IMAGE=public.ecr.aws/docker/library/registry:2
 CLUSTER_NAME=kind-gpu-sim
-LOAD_IMAGE_NAME=not-set
+
 # Detect OS
 OS_TYPE=$(uname -s)
 if [[ "$OS_TYPE" == "Darwin" ]]; then
@@ -385,13 +385,18 @@ function usage() {
 }
 
 function load_image() {
-  if [ "$CONTAINER_RUNTIME" = "docker" ]; then
-    echo "Running: load docker-image ${LOAD_IMAGE_NAME} --name ${CLUSTER_NAME}"
-    kind load docker-image "${LOAD_IMAGE_NAME}" --name "${CLUSTER_NAME}"
+  if [ -n "${LOAD_IMAGE_NAME:-}" ]; then
+    if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+      echo "Running: load docker-image ${LOAD_IMAGE_NAME} --name ${CLUSTER_NAME}"
+      kind load docker-image "${LOAD_IMAGE_NAME}" --name "${CLUSTER_NAME}"
+    else
+      cr save "${LOAD_IMAGE_NAME}" -o /tmp/image.tar
+      kind load image-archive /tmp/image.tar --name "${CLUSTER_NAME}"
+      rm -f /tmp/image.tar
+    fi
   else
-    cr save "${LOAD_IMAGE_NAME}" -o /tmp/image.tar
-    kind load image-archive /tmp/image.tar --name "${CLUSTER_NAME}"
-    rm -f /tmp/image.tar
+    echo "ERROR: --image-name is required for load command" >&2
+    exit 1
   fi
 }
 

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -180,6 +180,9 @@ patch_dockerfile() {
 function build_and_push_images() {
   gpu_type="$1"
 
+  # Remove any latent /tmp/image.tar as cr save fails instead of overwriting
+  rm -f /tmp/image.tar
+
   if [ "$gpu_type" = "nvidia" ]; then
     echo " Building NVIDIA device plugin locally..."
     [ ! -d k8s-device-plugin-nvidia ] && git clone https://github.com/NVIDIA/k8s-device-plugin.git k8s-device-plugin-nvidia

--- a/hack/kind-gpu-sim.sh
+++ b/hack/kind-gpu-sim.sh
@@ -209,7 +209,7 @@ function build_and_push_images() {
   fi
 
   echo " Building ROCm plugin images locally..."
-  [ ! -d k8s-device-plugin-rocm ] && git clone https://github.com/RadeonOpenCompute/k8s-device-plugin.git k8s-device-plugin-rocm
+  [ ! -d k8s-device-plugin-rocm ] && git clone https://github.com/ROCm/k8s-device-plugin.git k8s-device-plugin-rocm
   cd k8s-device-plugin-rocm
 
   patch_dockerfile "$gpu_type"


### PR DESCRIPTION
- Removes the need to download it from an external source
- Still keeps the ability to make temporary edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-enabled Kubernetes cluster simulation (create, delete, load) with ROCm/NVIDIA modes, registry and cluster name options, image-load support, local registry integration, automatic container-runtime and OS handling, and automated building/deploying of GPU device plugins.
* **Chores**
  * Installer flow updated to install the helper script into a local bin location before related setup and image-loading steps run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->