### PR TITLE
mcv: detect vLLM mega-AOT cache layout

### DIFF
--- a/mcv/pkg/cache/vllm.go
+++ b/mcv/pkg/cache/vllm.go
@@ -306,19 +306,17 @@ func detectBinaryCache(hashDir string) ([]BinaryCacheMetadata, error) {
 }
 
 // detectMegaAOTEntries walks torch_aot_compile/ and returns metadata for
-// each child hash dir that contains a mega-AOT bundle. The second return
-// value is the number of hash directories considered (whether or not they
+// each child hash dir that contains a mega-AOT bundle. The count return
+// is the number of hash directories considered (whether or not they
 // yielded valid metadata), so the caller can keep its entry count in sync.
-func detectMegaAOTEntries(aotDir string) ([]VLLMCacheMetadata, int) {
-	entries, err := os.ReadDir(aotDir)
+func detectMegaAOTEntries(aotDir string) (entries []VLLMCacheMetadata, count int) {
+	dirEntries, err := os.ReadDir(aotDir)
 	if err != nil {
 		logging.Warnf("Failed to read %s: %v", aotDir, err)
 		return nil, 0
 	}
 
-	var out []VLLMCacheMetadata
-	count := 0
-	for _, entry := range entries {
+	for _, entry := range dirEntries {
 		if !entry.IsDir() {
 			continue
 		}
@@ -330,13 +328,13 @@ func detectMegaAOTEntries(aotDir string) ([]VLLMCacheMetadata, int) {
 			continue
 		}
 		logging.Debugf("Detected mega-AOT cache for hash: %s", entry.Name())
-		out = append(out, VLLMCacheMetadata{
+		entries = append(entries, VLLMCacheMetadata{
 			VllmHash:           entry.Name(),
 			CacheFormat:        BinaryCacheFormat,
 			BinaryCacheEntries: megaData,
 		})
 	}
-	return out, count
+	return entries, count
 }
 
 // detectMegaAOTCache detects the mega-AOT bundle layout in a hash directory.

--- a/mcv/pkg/cache/vllm.go
+++ b/mcv/pkg/cache/vllm.go
@@ -27,6 +27,13 @@ const (
 	// Cache format constants
 	BinaryCacheFormat = "binary"
 	CUDABackend       = "cuda"
+
+	// torchAOTCompileDirName is the extra directory vLLM introduces above
+	// the per-model hash dir when VLLM_USE_AOT_COMPILE is enabled.
+	torchAOTCompileDirName = "torch_aot_compile"
+	// megaAOTSaveFormat marks a BinaryCacheMetadata entry as produced by
+	// the mega-AOT flow (single bundled "model" blob per rank dir).
+	megaAOTSaveFormat = "mega-aot"
 )
 
 // VLLMCache represents a VLLM-style compile cache (e.g., torch_inductor or fxgraph)
@@ -63,7 +70,8 @@ func DetectVLLMCache(cacheDir string) *VLLMCache {
 		name := d.Name()
 		if strings.HasSuffix(name, "vllm_compile_cache.py") ||
 			strings.Contains(path, "inductor_cache") ||
-			strings.Contains(path, "fxgraph") {
+			strings.Contains(path, "fxgraph") ||
+			strings.Contains(path, torchAOTCompileDirName) {
 			found = true
 			return filepath.SkipDir
 		}
@@ -88,6 +96,19 @@ func DetectVLLMCache(cacheDir string) *VLLMCache {
 				if !entry.IsDir() {
 					continue
 				}
+
+				// Mega-AOT layout wraps per-model hash dirs under
+				// torch_aot_compile/. Recurse one level and treat each
+				// child as a hash dir.
+				if entry.Name() == torchAOTCompileDirName {
+					aotMeta, aotCount := detectMegaAOTEntries(
+						filepath.Join(torchCompileCachePath, entry.Name()),
+					)
+					metadata = append(metadata, aotMeta...)
+					count += aotCount
+					continue
+				}
+
 				count++
 				hashDir := filepath.Join(torchCompileCachePath, entry.Name())
 
@@ -282,6 +303,75 @@ func detectBinaryCache(hashDir string) ([]BinaryCacheMetadata, error) {
 	}
 
 	return binaryCaches, nil
+}
+
+// detectMegaAOTEntries walks torch_aot_compile/ and returns metadata for
+// each child hash dir that contains a mega-AOT bundle. The second return
+// value is the number of hash directories considered (whether or not they
+// yielded valid metadata), so the caller can keep its entry count in sync.
+func detectMegaAOTEntries(aotDir string) ([]VLLMCacheMetadata, int) {
+	entries, err := os.ReadDir(aotDir)
+	if err != nil {
+		logging.Warnf("Failed to read %s: %v", aotDir, err)
+		return nil, 0
+	}
+
+	var out []VLLMCacheMetadata
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		count++
+		hashDir := filepath.Join(aotDir, entry.Name())
+		megaData, megaErr := detectMegaAOTCache(hashDir)
+		if megaErr != nil || len(megaData) == 0 {
+			logging.Warnf("No mega-AOT artifacts in %s: %v", hashDir, megaErr)
+			continue
+		}
+		logging.Debugf("Detected mega-AOT cache for hash: %s", entry.Name())
+		out = append(out, VLLMCacheMetadata{
+			VllmHash:           entry.Name(),
+			CacheFormat:        BinaryCacheFormat,
+			BinaryCacheEntries: megaData,
+		})
+	}
+	return out, count
+}
+
+// detectMegaAOTCache detects the mega-AOT bundle layout in a hash directory.
+// The layout places one bundled artifact at {hashDir}/rank_X_Y/model, with
+// inductor/triton state as a shared sibling at {hashDir}/inductor_cache/.
+// Unlike the per-piecewise binary format, no cache_key_factors.json is
+// emitted, so hash/env fields are left empty.
+func detectMegaAOTCache(hashDir string) ([]BinaryCacheMetadata, error) {
+	entries, err := os.ReadDir(hashDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read hash directory: %w", err)
+	}
+
+	var out []BinaryCacheMetadata
+	rankDirRegex := regexp.MustCompile(`^rank_\d+_\d+$`)
+	for _, entry := range entries {
+		if !entry.IsDir() || !rankDirRegex.MatchString(entry.Name()) {
+			continue
+		}
+		modelPath := filepath.Join(hashDir, entry.Name(), "model")
+		info, err := os.Stat(modelPath)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		out = append(out, BinaryCacheMetadata{
+			Rank:            entry.Name(),
+			ArtifactCount:   1,
+			ArtifactNames:   []string{"model"},
+			CacheSaveFormat: megaAOTSaveFormat,
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no mega-AOT artifacts detected")
+	}
+	return out, nil
 }
 
 func (v *VLLMCache) Name() string { return constants.VLLM }

--- a/mcv/pkg/cache/vllm_test.go
+++ b/mcv/pkg/cache/vllm_test.go
@@ -1,0 +1,121 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const megaAOTHash = "d5313e9d59c8842ac8d3b743f0c1c018ea9b101c4f9ae1134b8c85e61557f070"
+
+// writeTestFile is a test helper that creates parent dirs and writes content.
+func writeTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	assert.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	assert.NoError(t, os.WriteFile(path, content, 0o644))
+}
+
+// newMegaAOTCache builds a fake mega-AOT cache tree rooted at cacheDir with
+// the given hash and rank dirs. Each rank dir gets a "model" file plus a
+// shared inductor_cache/triton/0/ kernel dir next to the rank dirs.
+func newMegaAOTCache(t *testing.T, cacheDir, hash string, ranks []string) {
+	t.Helper()
+	hashDir := filepath.Join(cacheDir, "torch_compile_cache", torchAOTCompileDirName, hash)
+	for _, rank := range ranks {
+		writeTestFile(t, filepath.Join(hashDir, rank, "model"), []byte("mega-aot-blob"))
+	}
+	writeTestFile(t, filepath.Join(hashDir, "inductor_cache", "triton", "0", "kernel.cubin"), []byte("cubin"))
+}
+
+func TestDetectVLLMCache_NoCacheReturnsNil(t *testing.T) {
+	assert.Nil(t, DetectVLLMCache(t.TempDir()))
+}
+
+func TestDetectVLLMCache_MegaAOTSingleRank(t *testing.T) {
+	cacheDir := t.TempDir()
+	newMegaAOTCache(t, cacheDir, megaAOTHash, []string{"rank_0_0"})
+
+	got := DetectVLLMCache(cacheDir)
+	assert.NotNil(t, got)
+	assert.Equal(t, 1, got.EntryCount())
+
+	meta := got.Metadata()
+	assert.Len(t, meta, 1)
+
+	entry, ok := meta[0].(VLLMCacheMetadata)
+	assert.True(t, ok, "expected VLLMCacheMetadata, got %T", meta[0])
+	assert.Equal(t, megaAOTHash, entry.VllmHash)
+	assert.Equal(t, BinaryCacheFormat, entry.CacheFormat)
+	assert.Len(t, entry.BinaryCacheEntries, 1)
+
+	bin := entry.BinaryCacheEntries[0]
+	assert.Equal(t, "rank_0_0", bin.Rank)
+	assert.Equal(t, 1, bin.ArtifactCount)
+	assert.Equal(t, []string{"model"}, bin.ArtifactNames)
+	assert.Equal(t, megaAOTSaveFormat, bin.CacheSaveFormat)
+
+	// Labels flag the cache as binary format, matching existing manifest
+	// consumers and the preflight check.
+	labels := got.Labels()
+	assert.Equal(t, BinaryCacheFormat, labels[cacheVLLMImageFormat])
+	assert.Equal(t, "1", labels[cacheVLLMImageEntryCount])
+}
+
+func TestDetectVLLMCache_MegaAOTMultiRank(t *testing.T) {
+	cacheDir := t.TempDir()
+	newMegaAOTCache(t, cacheDir, megaAOTHash, []string{"rank_0_0", "rank_1_0"})
+
+	got := DetectVLLMCache(cacheDir)
+	assert.NotNil(t, got)
+
+	meta := got.Metadata()
+	assert.Len(t, meta, 1)
+	entry, ok := meta[0].(VLLMCacheMetadata)
+	assert.True(t, ok)
+	assert.Len(t, entry.BinaryCacheEntries, 2)
+
+	ranks := []string{entry.BinaryCacheEntries[0].Rank, entry.BinaryCacheEntries[1].Rank}
+	assert.ElementsMatch(t, []string{"rank_0_0", "rank_1_0"}, ranks)
+}
+
+func TestDetectVLLMCache_MegaAOTSkipsRankWithoutModel(t *testing.T) {
+	cacheDir := t.TempDir()
+	hashDir := filepath.Join(cacheDir, "torch_compile_cache", torchAOTCompileDirName, megaAOTHash)
+	// rank_0_0 has model; rank_1_0 is an empty dir (e.g. partial write).
+	writeTestFile(t, filepath.Join(hashDir, "rank_0_0", "model"), []byte("blob"))
+	assert.NoError(t, os.MkdirAll(filepath.Join(hashDir, "rank_1_0"), 0o755))
+	writeTestFile(t, filepath.Join(hashDir, "inductor_cache", "fxgraph", "key"), []byte("x"))
+
+	got := DetectVLLMCache(cacheDir)
+	assert.NotNil(t, got)
+	entry := got.Metadata()[0].(VLLMCacheMetadata)
+	assert.Len(t, entry.BinaryCacheEntries, 1)
+	assert.Equal(t, "rank_0_0", entry.BinaryCacheEntries[0].Rank)
+}
+
+func TestDetectVLLMCache_MegaAOTMetadataMarshalsToManifest(t *testing.T) {
+	cacheDir := t.TempDir()
+	newMegaAOTCache(t, cacheDir, megaAOTHash, []string{"rank_0_0"})
+
+	got := DetectVLLMCache(cacheDir)
+	assert.NotNil(t, got)
+
+	// Round-trip through the VLLMManifest shape used on disk, matching what
+	// the preflight check ingests at mcv/pkg/preflightcheck/vllm.go.
+	entries := make([]VLLMCacheMetadata, 0, len(got.Metadata()))
+	for _, m := range got.Metadata() {
+		entries = append(entries, m.(VLLMCacheMetadata))
+	}
+	data, err := json.Marshal(VLLMManifest{VLLM: entries})
+	assert.NoError(t, err)
+
+	var round VLLMManifest
+	assert.NoError(t, json.Unmarshal(data, &round))
+	assert.Len(t, round.VLLM, 1)
+	assert.Equal(t, BinaryCacheFormat, round.VLLM[0].CacheFormat)
+	assert.Len(t, round.VLLM[0].BinaryCacheEntries, 1)
+	assert.Equal(t, megaAOTSaveFormat, round.VLLM[0].BinaryCacheEntries[0].CacheSaveFormat)
+}


### PR DESCRIPTION
The mega-AOT flow (VLLM_USE_AOT_COMPILE) adds a torch_aot_compile/ indirection above per-model hash dirs and stores a single bundled "model" blob per rank, with no cache_key_factors.json. DetectVLLMCache previously mis-read torch_aot_compile as a hash and returned empty metadata. Walk one level deeper for this layout and emit binary-format entries so manifest labels, summary, and preflight work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced vLLM cache detection to support mega-AOT compiled models with multi-rank configurations and automatic torch_aot_compile directory recognition as valid cache evidence.

* **Tests**
  * Added comprehensive test coverage for mega-AOT cache detection scenarios including single-rank and multi-rank configurations, rank directory validation, and manifest serialization round-trip verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->