### PR TITLE
chore: update Go version to 1.25.5 and improve AMD GPU handling

### DIFF
--- a/.github/workflows/mcv-build.yml
+++ b/.github/workflows/mcv-build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version: 1.25.5
 
       - name: Install required packages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ kind-config.yaml
 k8s-device-plugin-rocm/
 k8s-device-plugin-nvidia/
 config/secret/mutation.env
+
+mcv/_output/


### PR DESCRIPTION
- Update mcv-build workflow to use Go 1.25.5 to match go.mod requirements
- Add mcv/_output/ to .gitignore
- Fix AMD GPU struct field types to handle variable JSON responses