### PR TITLE
speedup builds

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -130,6 +130,8 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           build-args: BUILDPLATFORM=linux/amd64
           context: ${{ matrix.image.context }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Sign the images with GitHub OIDC Token
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}

--- a/.github/workflows/mcv-build-image.yml
+++ b/.github/workflows/mcv-build-image.yml
@@ -99,6 +99,8 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           build-args: BUILDPLATFORM=linux/amd64
           context: ${{ matrix.image.context }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Sign the images with GitHub OIDC Token
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ k8s-device-plugin-rocm/
 k8s-device-plugin-nvidia/
 config/secret/mutation.env
 
+# MCV Builds
 mcv/_output/
+
+# AI Tools
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ OPERATOR_IMG ?= $(REPO)/operator:$(IMAGE_TAG)
 AGENT_IMG ?=$(REPO)/agent:$(IMAGE_TAG)
 EXTRACT_IMG ?=$(REPO)/gkm-extract:$(IMAGE_TAG)
 
+# Number of parallel jobs to use when running build-images. Default is 3, one for each image
+# being built. High number won't really speed it up. Parallels builds can be hard to debug,
+# so setting to 1 will make the builds sequential and easier to debug.
+MAX_JOBS ?= 3
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
@@ -223,7 +228,8 @@ build-image-gkm-extract:
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: build-images
-build-images: build-image-operator build-image-agent build-image-gkm-extract ## Build all container images.
+build-images: ## Build all container images in parallel (use MAX_JOBS=1 to build sequentially)
+	$(MAKE) -j$(MAX_JOBS) build-image-operator build-image-agent build-image-gkm-extract
 
 .PHONY: push-images
 push-images: ## Push all container image.


### PR DESCRIPTION
Had Claude analyze the Makefile and github workflow files and make recommendations on how to speedup GKM image builds locally and in CI. Implemented parallel builds in Makefile and GitHub Actions cache for both image-build and mcv-build-image workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image build performance by integrating GitHub Actions cache, enabling layer caching for faster rebuilds
  * Updated build process configuration to support parallel execution of image builds with option to run sequentially if needed
  * Extended version control ignore patterns to exclude build output directories and tool configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->