### PR TITLE
fix Node 20 error

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -100,7 +100,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to quay.io/gkm
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@v1.7
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         with:
           registry: ${{ matrix.image.registry }}

--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to quay.io/gkm
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@v1.7
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/mcv-build-image.yml
+++ b/.github/workflows/mcv-build-image.yml
@@ -71,7 +71,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to quay.io/gkm
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@v1.7
         if: ${{ fromJSON(steps.set-push.outputs.push_flag) }}
         with:
           registry: ${{ matrix.image.registry }}


### PR DESCRIPTION
github actions is failing with: "Node 20 is being deprecated." So podman login is not happening. Full error:

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

```
Updating the redhat-actions/podman-login@v1 from v1 to v1.7.