### PR TITLE
mcv container fix python3 error

### DIFF
--- a/mcv/images/Containerfile
+++ b/mcv/images/Containerfile
@@ -63,6 +63,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3-setuptools \
+    python3-wheel \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
@@ -107,8 +109,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     lsb-release \
     software-properties-common \
-    python3-setuptools \
-    python3-wheel \
     pciutils \
     hwdata \
  && rm -rf /var/lib/apt/lists/*
@@ -155,6 +155,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3-setuptools \
+    python3-wheel \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
@@ -200,6 +202,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3-setuptools \
+    python3-wheel \
  && rm -rf /var/lib/apt/lists/*
 
 # Install ROCm tools for AMD GPU detection (amd64 only; ROCm has no arm64 packages).
@@ -207,7 +211,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
     apt-get update && apt-get install -y --no-install-recommends \
         wget gnupg2 curl lsb-release software-properties-common \
-        python3-setuptools python3-wheel pciutils && \
+        pciutils && \
     rm -rf /var/lib/apt/lists/* && \
     wget -O /tmp/amdgpu-install.deb \
         https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${AMDGPU_VERSION}-1_all.deb && \


### PR DESCRIPTION
When using the latest MCV container image from quay.io, get a python3 error when trying to use to created an OCI image. Needed to add python3 related packages back to minimal (which amd inherits) and nvidia specific builds.

```
$ podman run --rm -it --privileged \
  -v ./mcv/example:/example \
  quay.io/gkm/mcv:latest bash -lc '
    /mcv -c -i quay.io/gkm/vector-add-cache:rocm \
        -d /example/vector-add-cache-rocm --no-gpu &&
    buildah push containers-storage:quay.io/gkm/vector-add-cache:rocm \
        oci-archive:/example/vector-add-cache-rocm.oci:quay.io/gkm/vector-add-cache:rocm
  '
INFO[2026-08-13 16:26:52] Setting log level: info
INFO[2026-08-13 16:26:52] Using buildah to build the image ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/CLGERUUZRLHT73J2VAUCCDR5ZG34VIZXGHFLZH6HGZRILMOKHGQQ/triton_poi_fused_cat_1.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/CLGERUUZRLHT73J2VAUCCDR5ZG34VIZXGHFLZH6HGZRILMOKHGQQ/triton_poi_fused_cat_1.json ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/HMTTLTSHCM2NA5635EIF3L7BMNOKCW3S5WXHFN6OW6TXPQXRUVMQ/triton_poi_fused_cat_1.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/HMTTLTSHCM2NA5635EIF3L7BMNOKCW3S5WXHFN6OW6TXPQXRUVMQ/triton_poi_fused_cat_1.json ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/HR47ZPBPY3VLPZ7QAWGK7AZ766NXCDFVNFN3EVNUKCQXKWGINCCA/triton_poi_fused__to_copy_embedding_0.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/HR47ZPBPY3VLPZ7QAWGK7AZ766NXCDFVNFN3EVNUKCQXKWGINCCA/triton_poi_fused__to_copy_embedding_0.json ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/LQYWECKW73MX7RAQM6XBQROH6T743RZBH6MGOVISEMPG7NNTO5SQ/triton_poi_fused_cat_0.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/LQYWECKW73MX7RAQM6XBQROH6T743RZBH6MGOVISEMPG7NNTO5SQ/triton_poi_fused_cat_0.json ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/N3ZI444ITBT3SIDLYQOCP3MUH5GVAAXV4RJFR74NOFFZQV5FBKBQ/triton_poi_fused__to_copy_embedding_0.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/N3ZI444ITBT3SIDLYQOCP3MUH5GVAAXV4RJFR74NOFFZQV5FBKBQ/triton_poi_fused__to_copy_embedding_0.json ERRO[2026-08-13 16:26:52] Failed to compute dummy key for Triton cache JSON  err="critical error during cache key generation: failed to get Triton installation fingerprint: exec: \"python3\": executable file not found in $PATH" fields.file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/WZA7FZWZVFQMAIMIQ4RLRJOE4YZDITHSDQ4MFXFQW2YT7FBPE3WA/triton_poi_fused_cat_0.json file=/tests/vllm-cache/torch_compile_cache/d4ec7c2a7d/rank_0_0/triton_cache/WZA7FZWZVFQMAIMIQ4RLRJOE4YZDITHSDQ4MFXFQW2YT7FBPE3WA/triton_poi_fused_cat_0.json WARN[2026-08-13 16:26:52] Failed to process hash entry d4ec7c2a7d: failed to detect Triton cache INFO[2026-08-13 16:26:52] Detected cache components: [vllm]
```