### PR TITLE
fix(mcv): install python3 and build MCV image in example CI

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -61,8 +61,13 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Pull MCV builder image
-        run: podman pull quay.io/gkm/mcv:latest
+      - name: Build MCV builder image from checkout
+        run: |
+          podman build \
+            --platform linux/amd64 \
+            --target mcv-minimal \
+            -t quay.io/gkm/mcv:latest \
+            -f mcv/images/Containerfile .
 
       - name: Build images inside MCV container and load to host
         env:

--- a/mcv/images/Containerfile
+++ b/mcv/images/Containerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3 \
     python3-setuptools \
     python3-wheel \
  && rm -rf /var/lib/apt/lists/*
@@ -155,6 +156,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3 \
     python3-setuptools \
     python3-wheel \
  && rm -rf /var/lib/apt/lists/*
@@ -202,6 +204,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netavark aardvark-dns \
     fuse-overlayfs fuse3 \
     hwdata \
+    python3 \
     python3-setuptools \
     python3-wheel \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add explicit `python3` to `mcv-minimal`, `mcv-nvidia`, and `mcv-unified` runtime stages so Triton cache key generation can run.
- Build `mcv-minimal` from the checked-out code in the MCV Example Image Build workflow instead of pulling `quay.io/gkm/mcv:latest`, which was stale on PRs and raced with the post-merge image push on main.

## Test plan
- [ ] MCV Example Image Build workflow passes on this PR
- [ ] `vector-add-cache-rocm` and other example cache images build successfully inside the MCV container


Made with [Cursor](https://cursor.com)