### PR TITLE
fix(mcv): switch to vfs storage and remove fuse-overlayfs dependencies

### DIFF
--- a/mcv/images/Containerfile
+++ b/mcv/images/Containerfile
@@ -61,7 +61,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     buildah \
     netavark aardvark-dns \
-    fuse-overlayfs fuse3 \
     hwdata \
     python3 \
     python3-setuptools \
@@ -69,7 +68,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="overlay"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n[storage.options]\nmount_program="/usr/bin/fuse-overlayfs"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv
@@ -154,7 +153,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     buildah \
     netavark aardvark-dns \
-    fuse-overlayfs fuse3 \
     hwdata \
     python3 \
     python3-setuptools \
@@ -162,7 +160,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="overlay"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n[storage.options]\nmount_program="/usr/bin/fuse-overlayfs"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv
@@ -202,7 +200,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6 \
     buildah \
     netavark aardvark-dns \
-    fuse-overlayfs fuse3 \
     hwdata \
     python3 \
     python3-setuptools \
@@ -232,7 +229,7 @@ fi
 
 # Configure container storage
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="overlay"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n[storage.options]\nmount_program="/usr/bin/fuse-overlayfs"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv


### PR DESCRIPTION
VFS storage driver avoids nested overlay-on-overlay issues when running buildah inside containers. Remove fuse-overlayfs/fuse3 packages as they are only needed for overlay storage driver.

Resolves "mkdir /io.triton.manifest: operation not permitted" errors when running MCV in Docker/Podman environments (common on Fedora where docker is podman).