### PR TITLE
running MCV without --privileged

### DIFF
--- a/.github/workflows/mcv-build-example-images.yml
+++ b/.github/workflows/mcv-build-example-images.yml
@@ -96,11 +96,11 @@ jobs:
             archive="${out_dir}/${tag}.oci"
 
             echo "==> Building ${image} using MCV container from /work/${reldir}"
-            podman run --rm --privileged \
+            podman run --rm \
               -e TAG="${tag}" \
               -e IMAGE="${image}" \
               -e RELDIR="${reldir}" \
-              -v "${GITHUB_WORKSPACE}:/work:rw" \
+              -v "${GITHUB_WORKSPACE}:/work:Z,U" \
               quay.io/gkm/mcv:latest bash -lc '
                 set -euo pipefail
                 /mcv -l info -c -i "$IMAGE" -d "/work/$RELDIR" &&

--- a/.github/workflows/mcv-build.yml
+++ b/.github/workflows/mcv-build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
 
       - name: Prepare vendored dependencies
         working-directory: mcv

--- a/Makefile
+++ b/Makefile
@@ -694,7 +694,7 @@ UNDEPLOY_SCRIPT ?= $(shell pwd)/hack/undeploy.sh
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.12.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -715,7 +715,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/mcv/README.md
+++ b/mcv/README.md
@@ -29,9 +29,57 @@ A Model/GPU kernel cache container packaging utility inspired by
 ### Install dependencies
 
 ```bash
-sudo dnf install gpgme-devel
-sudo dnf install btrfs-progs-devel
+sudo dnf install -y gpgme-devel btrfs-progs-devel
 ```
+OR
+```bash
+sudo apt install -y libgpgme-dev libbtrfs-dev uidmap
+```
+
+On Ubuntu 24.04, *running* `mcv` unprivileged to build cache images (its
+embedded buildah creates a user namespace) requires unprivileged user
+namespaces, which Ubuntu restricts by default via AppArmor. This is only needed
+at runtime — compiling with `make build` does not need it. There are two ways to
+allow it.
+
+**Preferred — scoped AppArmor profile.** Grant the `userns` permission only to
+the `mcv` binary, leaving the global restriction in place for every other
+program. Create `/etc/apparmor.d/mcv` (adjust the path to match your installed
+binary):
+
+```bash
+abi <abi/4.0>,
+include <tunables/global>
+
+profile mcv /home/<user>/go/bin/mcv {
+  userns,
+  include if exists <local/mcv>
+}
+```
+
+Then load it:
+
+```bash
+sudo apparmor_parser -r /etc/apparmor.d/mcv
+```
+
+When running MCV inside a container instead of natively, apply the same `userns`
+permission to the container runtime's profile (e.g. `podman`/`rootlesskit`)
+rather than to `mcv`.
+
+**Simpler but less secure — disable the restriction globally.** This re-enables
+unprivileged user namespaces for *all* programs, weakening a defense-in-depth
+protection against kernel exploits that abuse user namespaces. Prefer the scoped
+profile above; use this only on disposable/dev machines:
+
+```bash
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+# To persist across reboots:
+echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/99-userns.conf
+ ```
+
+### Build and Install
 
 Build the binary:
 
@@ -110,6 +158,7 @@ Two image variants are available:
 **How it works:** With `--no-gpu`, MCV extracts GPU information (backend, architecture, warp size) from cache metadata rather than detecting actual hardware. The cache files created by vLLM/Triton already contain all necessary GPU information in environment variables.
 
 **GPU access flags** (e.g., `--gpus all` for NVIDIA, `--device /dev/kfd --device /dev/dri` for AMD) are **ONLY** required for GPU validation/preflight checks. They are **NOT** needed when using `--no-gpu` for cache creation or extraction.
+When using `podman run --device`, `--group-add keep-groups` may be needed for device access. But `--group-add keep-groups` requires crun (not runc).
 
 For detailed usage examples, container configuration, GPU access requirements, and CI/CD integration, see [docs/no-gpu-usage.md](./docs/no-gpu-usage.md).
 
@@ -552,25 +601,61 @@ To use docker on the host with an MCV image, you need to mount the cache
 directory to the container and run the following command:
 
 ```bash
-docker run --rm -it --privileged \
-  -v <path-to-cache>/example:/example \
+# Buildah storage is at /home/appuser/.local/share/containers (owned by UID 1000).
+# Mount a writable host directory there so --user 1000:1000 can write regardless
+# of the host user's UID. Using --user $(id -u):$(id -g) fails whenever the host
+# UID is not 1000, because those pre-created paths are owned by UID 1000 in the image.
+sudo install -d -o 1000 -g 1000 -m 700 /tmp/mcv-storage
+
+docker run --rm -it \
+  --user 1000:1000 \
+  --security-opt seccomp=unconfined \
+  --security-opt apparmor=unconfined \
+  -v <path-to-cache>/example:/example:Z \
+  -v /tmp/mcv-storage:/home/appuser/.local/share/containers:Z \
   quay.io/gkm/mcv bash -lc '
     /mcv -c -i quay.io/gkm/vector-add-cache:rocm \
         -d /example/vector-add-cache-rocm --no-gpu &&
     buildah push containers-storage:quay.io/gkm/vector-add-cache:rocm \
         docker-archive:/example/vector-add-cache-rocm.tar:quay.io/gkm/vector-add-cache:rocm
   '
+WARN[2025-09-11 16:46:54] running newgidmap: exit status 1: newgidmap: write to gid_map failed: Operation not permitted
+WARN[2025-09-11 16:46:54] /usr/bin/newgidmap should be setgid or have filecaps setgid
+WARN[2025-09-11 16:46:54] Falling back to single mapping
+WARN[2025-09-11 16:46:54] Error running newuidmap: exit status 1: newuidmap: write to uid_map failed: Operation not permitted
+WARN[2025-09-11 16:46:54] Falling back to single mapping
 INFO[2025-09-11 16:46:54] Setting log level: info
 INFO[2025-09-11 16:46:54] Using buildah to build the image
 INFO[2025-09-11 16:46:54] Detected cache components: [triton]
 INFO[2025-09-11 16:46:55] Image built! 8ce4bc2e98abfa8c0a5a6f6046c1c7bc8ac09805ecb029427a995dc2897828f8
 INFO[2025-09-11 16:46:55] OCI image created successfully.
+WARN[0000] running newgidmap: exit status 1: newgidmap: write to gid_map failed: Operation not permitted
+WARN[0000] /usr/bin/newgidmap should be setgid or have filecaps setgid
+WARN[0000] Falling back to single mapping
+WARN[0000] Error running newuidmap: exit status 1: newuidmap: write to uid_map failed: Operation not permitted
+WARN[0000] Falling back to single mapping
 Getting image source signatures
 Copying blob 24b82d6fef87 done
 Copying config 8ce4bc2e98 done
 Writing manifest to image destination
 Storing signatures
 ```
+
+> **NOTE:** The Warnings are known and everything still works fine.
+> An include library is making a system call that it doesn't have permission for,
+> so it fails and falls back to another method that succeeds.
+>
+> **Security note — `seccomp=unconfined` / `apparmor=unconfined`.** MCV runs
+> buildah *inside* the container to assemble the OCI image, which needs
+> `mount`/`unshare`/`pivot_root` and user-namespace operations that Docker's
+> default seccomp and AppArmor profiles block for non-privileged containers.
+> Disabling both is a deliberate, security-reviewed fallback — it is far narrower
+> than `--privileged` (no added capabilities, host devices, or host namespaces),
+> and the blast radius is bounded: the container runs as a non-root user
+> (`--user`), performs a single packaging task, and is removed on exit (`--rm`).
+> To harden further, replace these flags with scoped seccomp and AppArmor
+> profiles that allow only buildah's required syscalls/operations, or run the
+> same command under **rootless Podman**, which needs neither flag.
 
 Then on host:
 
@@ -596,8 +681,8 @@ To use podman on the host with an MCV image, you need to mount the cache
 directory to the container and run the following command:
 
 ```bash
-podman run --rm -it --privileged \
-  -v <path-to-cache>/example:/example \
+podman run --rm -it \
+  -v <path-to-cache>/example:/example:Z,U \
   quay.io/gkm/mcv bash -lc '
     /mcv -c -i quay.io/gkm/vector-add-cache:rocm \
         -d /example/vector-add-cache-rocm --no-gpu &&

--- a/mcv/docs/no-gpu-usage.md
+++ b/mcv/docs/no-gpu-usage.md
@@ -40,13 +40,18 @@ make build-image-mcv-no-gpu
 # or directly:
 podman build --target mcv-minimal -t quay.io/gkm/mcv:no-gpu -f mcv/images/Containerfile .
 
-# Use (MCV pushes directly to the registry; mount auth and fuse device for buildah)
+# Use — --create builds the image into the container's local containers-storage;
+# chain `buildah push` in the same run so it reaches the registry before --rm
+# removes the container (and its store). Mount registry auth for buildah (the
+# image runs as appuser, UID 1000, so mount it under that user's home).
 podman run --rm \
-  --device /dev/fuse \
-  -v /path/to/cache:/cache \
-  -v ${HOME}/.config/containers/auth.json:/run/containers/0/auth.json:ro \
+  --userns=keep-id:uid=1000,gid=1000 \
+  -v /path/to/cache:/cache:ro \
+  -v ${HOME}/.config/containers/auth.json:/home/appuser/.config/containers/auth.json:ro \
+  --entrypoint sh \
   quay.io/gkm/mcv:no-gpu \
-  --create --image quay.io/myorg/cache:v1 --dir /cache --no-gpu
+  -c "/mcv --create --image quay.io/myorg/cache:v1 --dir /cache --no-gpu \
+      && buildah push quay.io/myorg/cache:v1"
 ```
 
 ### Unified Image (For GPU validation - NVIDIA + AMD)
@@ -61,16 +66,31 @@ make build-image-mcv
 # or directly:
 podman build --target mcv-unified -t quay.io/gkm/mcv:unified -f mcv/images/Containerfile .
 
-# Use with NVIDIA GPU
+# Use with NVIDIA GPU (device nodes are world-accessible; no group needed)
 podman run --rm --device nvidia.com/gpu=all \
-  -v /path/to/cache:/cache quay.io/gkm/mcv:unified \
+  -v /path/to/cache:/cache:U quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/cache:v1 --dir /cache
 
 # Use with AMD GPU
-podman run --rm --device /dev/kfd --device /dev/dri \
-  -v /path/to/cache:/cache quay.io/gkm/mcv:unified \
+podman run --rm --device /dev/kfd --device /dev/dri --group-add keep-groups \
+  -v /path/to/cache:/cache:U quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/cache:v1 --dir /cache
 ```
+
+On hosts with group-restricted GPU devices, the documented device mappings can make
+amd-smi or rocm-smi fail. Add a runtime-supported mapping, such as Podman
+`--group-add keep-groups` with crun or explicit host device GIDs, and run GPU preflight
+as appuser.
+
+**Writable mounts (rootless).** Extraction writes into the mounted directory as the
+image's non-root user, so a plain rootless bind mount can fail with `permission
+denied`. Append `:U` to every writable mount (e.g. `-v /cache:/cache:U`) so Podman
+chowns the mount to the container user; on SELinux-enforcing hosts also add `:Z`
+(private to this container) or `:z` (shared) — for example `:U,Z`. Note that `:U`
+recursively changes ownership of the host directory; if that is undesirable, use
+`--userns=keep-id` instead to map your host UID into the container so existing
+ownership works without a chown. Docker has no `:U` — use `--user $(id -u):$(id -g)`
+there. Read-only mounts (`--create`) do not need `:U`.
 
 ## Usage Examples
 
@@ -82,13 +102,17 @@ mcv --create --image quay.io/myorg/vllm-cache:v1 \
     --dir ~/.cache/vllm/torch_compile_cache \
     --no-gpu
 
-# In container (minimal image; MCV pushes to the registry directly)
+# In container (minimal image) — --create stores the image in the container's
+# local containers-storage; chain `buildah push` so it reaches the registry
+# before --rm removes the store. Mount registry auth under appuser's home.
 podman run --rm \
-  --device /dev/fuse \
+  --userns=keep-id:uid=1000,gid=1000 \
   -v ~/.cache/vllm:/cache:ro \
-  -v ${HOME}/.config/containers/auth.json:/run/containers/0/auth.json:ro \
+  -v ${HOME}/.config/containers/auth.json:/home/appuser/.config/containers/auth.json:ro \
+  --entrypoint sh \
   quay.io/gkm/mcv:no-gpu \
-  --create --image quay.io/myorg/vllm-cache:v1 --dir /cache --no-gpu
+  -c "/mcv --create --image quay.io/myorg/vllm-cache:v1 --dir /cache --no-gpu \
+      && buildah push quay.io/myorg/vllm-cache:v1"
 ```
 
 ### Extracting Cache (No GPU Required)
@@ -101,7 +125,7 @@ mcv --extract --image quay.io/myorg/vllm-cache:v1 \
 
 # In container (minimal image)
 podman run --rm \
-  -v ~/.cache/vllm:/cache \
+  -v ~/.cache/vllm:/cache:U \
   quay.io/gkm/mcv:no-gpu \
   --extract --image quay.io/myorg/vllm-cache:v1 --dir /cache --no-gpu
 ```
@@ -116,8 +140,8 @@ mcv --extract --image quay.io/myorg/vllm-cache:v1 \
 
 # In container (full image)
 podman run --rm \
-  --device /dev/kfd --device /dev/dri \
-  -v ~/.cache/vllm:/cache \
+  --device /dev/kfd --device /dev/dri --group-add keep-groups \
+  -v ~/.cache/vllm:/cache:U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/vllm-cache:v1 --dir /cache
 ```
@@ -130,7 +154,7 @@ mcv --check-compat --image quay.io/myorg/vllm-cache:v1
 
 # In container
 podman run --rm \
-  --device /dev/kfd --device /dev/dri \
+  --device /dev/kfd --device /dev/dri --group-add keep-groups \
   quay.io/gkm/mcv:unified \
   --check-compat --image quay.io/myorg/vllm-cache:v1
 ```
@@ -150,31 +174,53 @@ build-cache-image:
         # Run vLLM to generate cache
         python generate_cache.py
 
-    - name: Build cache OCI image
+    - name: Build and push cache OCI image
       run: |
-        podman run --rm --privileged \
+        # --create stores the image in the container's local containers-storage,
+        # so push it in the same run — the store is gone once --rm removes the
+        # container. Mount registry auth under appuser's home (image runs as UID 1000).
+        podman run --rm \
+          --userns=keep-id:uid=1000,gid=1000 \
           -v $(pwd)/.cache/vllm:/cache:ro \
+          -v ${HOME}/.config/containers/auth.json:/home/appuser/.config/containers/auth.json:ro \
+          --entrypoint sh \
           quay.io/gkm/mcv:no-gpu \
-          --create --image quay.io/myorg/vllm-cache:${{ github.sha }} \
-          --dir /cache --no-gpu
-
-    - name: Push cache image
-      run: |
-        podman push quay.io/myorg/vllm-cache:${{ github.sha }}
+          -c "/mcv --create --image quay.io/myorg/vllm-cache:${{ github.sha }} \
+                --dir /cache --no-gpu \
+              && buildah push quay.io/myorg/vllm-cache:${{ github.sha }}"
 ```
 
 ## GPU Access Requirements
 
 ### When GPU Access Flags Are Required
 
-**NVIDIA GPUs:**
+**NVIDIA GPUs:** (device nodes are world-accessible — no group needed)
 - Docker: `--gpus all` (or `--gpus device=0,1` for specific devices)
 - Podman: `--device nvidia.com/gpu=all`
 - **ONLY needed for**: GPU validation/preflight checks (extract without `--no-gpu`, compatibility checks)
 - **NOT needed for**: Creating or extracting with `--no-gpu` flag
 
-**AMD GPUs:**
-- Docker & Podman: `--device /dev/kfd --device /dev/dri`
+**AMD GPUs:** (`/dev/kfd` and `/dev/dri/*` are group-owned — the non-root user must join the render/video group)
+- Podman (crun): `--device /dev/kfd --device /dev/dri --group-add keep-groups` (preserves the host user's render/video groups)
+- Docker: `--device /dev/kfd --device /dev/dri`, plus a `--group-add <gid>` for each mapped device node's owning group (`keep-groups` is Podman/crun-only). Device paths and GIDs are host-specific — `/dev/dri/renderD128` and the `video` group may be absent, and `/dev/kfd` and the various `/dev/dri/*` nodes can each be owned by a different GID — so **derive a GID for each node that actually exists** and pass only the ones you found (never a bare or empty `--group-add`). For example:
+  ```bash
+  # Collect the distinct owning GIDs of the GPU nodes present on this host.
+  gpu_gids=$(for d in /dev/kfd /dev/dri/renderD* /dev/dri/card*; do
+    [ -e "$d" ] && stat -c '%g' "$d"
+  done | sort -u)
+  [ -n "$gpu_gids" ] || { echo "no GPU device nodes found" >&2; exit 1; }
+
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --device /dev/kfd --device /dev/dri \
+    $(printf -- '--group-add %s ' $gpu_gids) \
+    -v /path/to/cache:/cache \
+    quay.io/gkm/mcv:unified \
+    --extract --image quay.io/myorg/cache:v1 --dir /cache
+  ```
+  Docker has no `:U`; run as your host UID/GID with `--user "$(id -u):$(id -g)"`
+  and ensure the host cache directory is writable by that UID/GID.
+  Alternatively, require operators to supply the GIDs explicitly (e.g. `--group-add 44 --group-add 993`) when the device layout is known ahead of time.
 - **ONLY needed for**: GPU validation/preflight checks (extract without `--no-gpu`, compatibility checks)
 - **NOT needed for**: Creating or extracting with `--no-gpu` flag
 
@@ -187,16 +233,16 @@ podman run --rm \
   quay.io/gkm/mcv:no-gpu \
   --create --image quay.io/myorg/cache:v1 --dir /cache --no-gpu
 
-# NVIDIA GPU access required for validation
+# NVIDIA GPU access required for validation (world-accessible nodes; no group needed)
 podman run --rm --device nvidia.com/gpu=all \
-  -v /path/to/cache:/cache \
+  -v /path/to/cache:/cache:U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/cache:v1 --dir /cache
 
 # AMD GPU access required for validation
 podman run --rm \
-  --device /dev/kfd --device /dev/dri \
-  -v /path/to/cache:/cache \
+  --device /dev/kfd --device /dev/dri --group-add keep-groups \
+  -v /path/to/cache:/cache:U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/cache:v1 --dir /cache
 ```

--- a/mcv/docs/unified-mcv-container.md
+++ b/mcv/docs/unified-mcv-container.md
@@ -20,13 +20,16 @@ make build-image-mcv
 
 # NVIDIA
 podman run --rm --device nvidia.com/gpu=all \
-  -v /path/to/cache:/cache \
+  -v /path/to/cache:/cache:Z,U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/vllm-cache:v1 --dir /cache
 
-# AMD
+# AMD — device nodes are group-owned, so the non-root user (UID 1000) must join
+# the host render/video group. Podman: --group-add keep-groups (crun). Docker:
+# pass numeric --group-add GIDs. See "Running GPU Preflight as Non-Root".
 podman run --rm --device /dev/kfd --device /dev/dri \
-  -v /path/to/cache:/cache \
+  --group-add keep-groups \
+  -v /path/to/cache:/cache:Z,U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/vllm-cache:v1 --dir /cache
 ```
@@ -67,8 +70,8 @@ On CPU node:    both fail    → requires explicit --no-gpu flag
 # Works on any node - no GPU needed.
 # --create stores the OCI image in buildah's container-internal store;
 # chain buildah push so the image reaches the registry before --rm removes the container.
-podman run --rm --privileged \
-  -v ~/.cache/vllm:/cache:ro \
+podman run --rm \
+  -v ~/.cache/vllm:/cache:Z,U \
   --entrypoint sh \
   quay.io/gkm/mcv:unified \
   -c "/mcv --create --image quay.io/myorg/llama3-cache:v1 --dir /cache --no-gpu \
@@ -81,9 +84,9 @@ podman run --rm --privileged \
 
 ```bash
 # On NVIDIA node - automatically uses NVML
-podman run --rm --privileged \
+podman run --rm \
   --device nvidia.com/gpu=all \
-  -v ~/.cache/vllm:/cache \
+  -v ~/.cache/vllm:/cache:Z,U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/cuda-cache:v1 --dir /cache
 
@@ -96,9 +99,12 @@ podman run --rm --privileged \
 
 ```bash
 # On AMD node - automatically uses rocm-smi
-podman run --rm --privileged \
+# --group-add keep-groups joins the host render/video group so the non-root user
+# can open /dev/kfd and /dev/dri (Docker needs numeric --group-add GIDs instead).
+podman run --rm \
   --device /dev/kfd --device /dev/dri \
-  -v ~/.cache/vllm:/cache \
+  --group-add keep-groups \
+  -v ~/.cache/vllm:/cache:Z,U \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/rocm-cache:v1 --dir /cache
 
@@ -112,11 +118,87 @@ podman run --rm --privileged \
 
 ```bash
 # Automatically detects GPU and validates cache compatibility
-podman run --rm --privileged \
+podman run --rm \
   --device nvidia.com/gpu=all \
   quay.io/gkm/mcv:unified \
   --check-compat --image quay.io/myorg/cache:v1
 ```
+
+## Running GPU Preflight as Non-Root
+
+The MCV image runs as a non-root user (`appuser`, UID 1000) and no longer needs
+`--privileged`. During extraction and `--check-compat`, MCV shells out to the
+vendor tool (`amd-smi`/`rocm-smi`, `hl-smi`, or NVML) to read GPU info. Two
+things must be true for that to work as a non-root user:
+
+1. **The device nodes must be inside the container** — provide them with
+   `--device` (or a CDI/device-plugin), the same as before.
+2. **The user must be permitted to open them** — this depends on the device
+   node's mode and group *on the host*.
+
+Device-node permissions vary by vendor, which is why AMD needs an extra flag and
+NVIDIA/Gaudi do not:
+
+| Vendor | Typical device nodes | Typical mode/owner | Non-root needs a group? |
+|--------|----------------------|--------------------|--------------------------|
+| NVIDIA | `/dev/nvidia*` | `0666` (via nvidia-container-toolkit) | No |
+| Intel Gaudi | `/dev/accel/accel*`, `/dev/accel/accel_controlD*` | `0666 root:render` | No |
+| AMD | `/dev/kfd`, `/dev/dri/renderD*`, `/dev/dri/card*` | `0660 root:render` (+ `video`) | **Yes** |
+
+> Device permissions are host-specific — confirm with `ls -l /dev/...` on your
+> node. The GIDs are assigned by the host, so they cannot be baked into the
+> image; supply them (or preserve host groups) at run time.
+
+**NVIDIA** (nodes are world-accessible — device access only):
+
+```bash
+# Podman (CDI)
+podman run --rm --device nvidia.com/gpu=all quay.io/gkm/mcv:unified \
+  --check-compat --image quay.io/myorg/cache:v1
+# Docker
+docker run --rm --gpus all quay.io/gkm/mcv:unified \
+  --check-compat --image quay.io/myorg/cache:v1
+```
+
+**Intel Gaudi** (nodes are `0666` — device access only, no group needed):
+
+```bash
+podman run --rm --device /dev/accel quay.io/gkm/mcv:gaudi \
+  --check-compat --image quay.io/myorg/cache:v1
+```
+
+**AMD** (render/DRI nodes are group-owned — add the group):
+
+```bash
+# Podman rootless (crun) — keep the host user's supplementary groups.
+# Run this as a user that is a member of the render/video groups.
+podman run --rm \
+  --device /dev/kfd --device /dev/dri \
+  --group-add keep-groups \
+  quay.io/gkm/mcv:unified \
+  --check-compat --image quay.io/myorg/cache:v1
+
+# Docker — keep-groups is Podman/crun-only, so grant each GPU device node's
+# owning GID explicitly. Device paths and GIDs are host-specific: renderD128
+# and the "video" group may be absent, and /dev/kfd and the /dev/dri/* nodes
+# can each be owned by a different GID. Derive a GID for every node that exists
+# and pass only those (never a bare/empty --group-add).
+gpu_gids=$(for d in /dev/kfd /dev/dri/renderD* /dev/dri/card*; do
+  [ -e "$d" ] && stat -c '%g' "$d"
+done | sort -u)
+[ -n "$gpu_gids" ] || { echo "no GPU device nodes found" >&2; exit 1; }
+
+docker run --rm \
+  --device=/dev/kfd --device=/dev/dri \
+  $(printf -- '--group-add %s ' $gpu_gids) \
+  quay.io/gkm/mcv:unified \
+  --check-compat --image quay.io/myorg/cache:v1
+```
+
+> `--group-add keep-groups` requires the `crun` runtime (the Podman default);
+> it is a no-op under `runc`. For Docker, pass each device's GID with
+> `--group-add` — derive them per-node as above, or require operators to supply
+> the GIDs explicitly when the device layout is known ahead of time.
 
 ## Kubernetes Deployment
 
@@ -139,8 +221,16 @@ metadata:
 spec:
   template:
     spec:
-      nodeSelector:
-        hardware-type: gpu  # Required for GPU extraction without --no-gpu
+      # Pod-level securityContext. fsGroup chowns the PVC volume to GID 1000 so
+      # the non-root user (UID 1000) can write the extracted cache and manifest
+      # files. fsGroup and supplementalGroups are pod-level fields — they have no
+      # effect if placed under a container's securityContext.
+      securityContext:
+        fsGroup: 1000
+        # AMD only: /dev/kfd and /dev/dri/renderD* are group-owned
+        # (root:render, mode 0660), so the non-root user must join that group.
+        # NVIDIA and Gaudi device nodes are world-accessible (0666) and need none.
+        # supplementalGroups: [<render-gid-on-node>]
       containers:
       - name: mcv
         image: quay.io/gkm/mcv:unified
@@ -150,8 +240,18 @@ spec:
           - "quay.io/myorg/vllm-cache:v1"
           - "--dir"
           - "/cache"
+        # Request the GPU through its device plugin instead of privileged: true.
+        # The device plugin injects the device nodes and configures the device
+        # cgroup, so no elevated privileges are needed and the pod is scheduled
+        # onto a matching GPU node automatically.
+        resources:
+          limits:
+            nvidia.com/gpu: 1   # AMD: amd.com/gpu: 1  |  Gaudi: habana.ai/gaudi: 1
         securityContext:
-          privileged: true  # Access GPU device files
+          runAsNonRoot: true
+          runAsUser: 1000       # appuser (baked into the image)
+          runAsGroup: 1000      # without this K8s defaults to GID 0
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: cache
           mountPath: /cache
@@ -165,13 +265,13 @@ spec:
 ```
 
 **Benefits:**
-- ✅ Single Job definition works on NVIDIA or AMD GPU nodes
-- ✅ Simplifies deployment in mixed GPU clusters
-- ✅ CPU-only workflows supported with explicit `--no-gpu`
+- ✅ Runs unprivileged — GPU access comes from the device plugin, not `privileged: true`
+- ✅ The same image works on any vendor; swap the `resources.limits` GPU key per node type
+- ✅ CPU-only workflows supported with explicit `--no-gpu` (drop the GPU `resources.limits`)
 
 ### DaemonSet Deployment
 
-For cache pre-extraction on all GPU nodes:
+For cache pre-extraction on all NVIDIA GPU nodes:
 
 ```yaml
 apiVersion: apps/v1
@@ -187,7 +287,7 @@ spec:
       labels:
         app: mcv-cache-preparer
     spec:
-      # Runs on all GPU nodes (both NVIDIA and AMD)
+      # Runs on all nodes exposing the requested GPU resource.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -195,9 +295,15 @@ spec:
             - matchExpressions:
               - key: nvidia.com/gpu.present
                 operator: Exists
-            - matchExpressions:
-              - key: amd.com/gpu
-                operator: Exists
+            # - matchExpressions:
+            #  - key: amd.com/gpu
+            #    operator: Exists
+      # Pod-level securityContext. supplementalGroups is a pod-level field —
+      # it is silently ignored under a container securityContext.
+      securityContext:
+        # AMD only — join the render group that owns /dev/kfd and /dev/dri/*
+        # (NVIDIA/Gaudi device nodes are 0666 and need no supplemental group):
+        # supplementalGroups: [<render-gid-on-node>]
       containers:
       - name: mcv
         image: quay.io/gkm/mcv:unified
@@ -208,17 +314,40 @@ spec:
             /mcv --extract \
               --image quay.io/myorg/vllm-cache:v1 \
               --dir /kernel-caches/vllm
+        # GPU access via the device plugin — no privileged: true required.
+        resources:
+          limits:
+            nvidia.com/gpu: 1   # AMD: amd.com/gpu: 1  |  Gaudi: habana.ai/gaudi: 1
         securityContext:
-          privileged: true
+          runAsNonRoot: true
+          runAsUser: 1000       # appuser in the image; Containerfile asserts id -u appuser = 1000
+          runAsGroup: 1000      # without this K8s defaults to GID 0
+          allowPrivilegeEscalation: false
+        # The hostPath below must be writable by uid 1000 on each node.
         volumeMounts:
         - name: kernel-caches
           mountPath: /kernel-caches
       volumes:
       - name: kernel-caches
+        # DirectoryOrCreate makes this root:root (0755); pre-create it owned by
+        # UID/GID 1000 on each node, or use a PVC (see the note above) — fsGroup
+        # cannot fix hostPath ownership.
         hostPath:
           path: /kernel-caches
           type: DirectoryOrCreate
 ```
+
+> **Mixed-vendor clusters need one DaemonSet per vendor.** A DaemonSet applies one
+> identical pod spec to every node it runs on, and a pod can request only one
+> vendor's GPU resource. So even in a cluster that mixes NVIDIA, AMD, and Gaudi
+> nodes, a single DaemonSet requesting (say) `nvidia.com/gpu` runs only on the
+> NVIDIA nodes — the pods it tries to place on the AMD and Gaudi nodes stay
+> unschedulable, since those nodes don't advertise that resource. To cover every
+> vendor, deploy a separate DaemonSet for each, changing the `resources.limits`
+> key (`amd.com/gpu` / `habana.ai/gaudi`), the `nodeAffinity` match key, and — for
+> AMD only — adding `securityContext.supplementalGroups`. A single DaemonSet could
+> only span all vendors by running `privileged: true` and mounting the host `/dev`
+> directly, which is exactly what this unprivileged setup avoids.
 
 ## Testing
 
@@ -237,8 +366,13 @@ docker run --rm --gpus all \
 **AMD GPU Test:**
 ```bash
 # On a node with AMD GPU
+# AMD device nodes are group-owned; grant their GIDs (keep-groups is Podman-only).
+gpu_gids=$(for d in /dev/kfd /dev/dri/renderD* /dev/dri/card*; do
+  [ -e "$d" ] && stat -c '%g' "$d"
+done | sort -u)
 docker run --rm \
   --device=/dev/kfd --device=/dev/dri \
+  $(printf -- '--group-add %s ' $gpu_gids) \
   quay.io/gkm/mcv:unified \
   --extract --image quay.io/myorg/rocm-cache:v1 --dir /tmp/cache
 
@@ -268,10 +402,20 @@ jobs:
     steps:
       - name: Build vLLM cache OCI image
         run: |
+          # Buildah storage lives at /home/appuser/.local/share/containers inside
+          # the image (owned by UID 1000). Mount a writable host directory there
+          # so that --user 1000:1000 can write to it regardless of the runner UID.
+          sudo install -d -o 1000 -g 1000 -m 700 /tmp/mcv-storage
+
           # --builder docker loads the image into the Docker daemon so the
           # subsequent docker push step can find it on the host.
-          docker run --rm --privileged \
-            -v $(pwd)/.cache:/cache:ro \
+          docker run --rm \
+            --user 1000:1000 \
+            --group-add "$(stat -c '%g' /var/run/docker.sock)" \
+            --security-opt seccomp=unconfined \
+            --security-opt apparmor=unconfined \
+            -v $(pwd)/.cache:/cache:ro,Z \
+            -v /tmp/mcv-storage:/home/appuser/.local/share/containers:Z \
             -v /var/run/docker.sock:/var/run/docker.sock \
             quay.io/gkm/mcv:unified \
             --create --image quay.io/myorg/cache:${{ github.sha }} \
@@ -280,6 +424,43 @@ jobs:
       - name: Push to registry
         run: docker push quay.io/myorg/cache:${{ github.sha }}
 ```
+
+> **Why `--user 1000:1000` instead of `--user $(id -u):$(id -g)`?** Buildah's
+> storage is pinned to `/home/appuser/.local/share/containers` inside the image,
+> pre-created and owned by UID 1000 (`appuser`). Running as the host user's UID
+> (typically 1001 on GitHub-hosted runners) would make those paths unwritable.
+> Using a fixed `--user 1000:1000` keeps the UID consistent regardless of the
+> runner's own UID. The `-v /tmp/mcv-storage:/home/appuser/.local/share/containers`
+> mount gives UID 1000 a writable scratch area that does not outlive the job.
+>
+> **Why `--group-add`?** With `--builder docker`, MCV loads the built image into
+> the Docker daemon over the mounted `/var/run/docker.sock`. A rootful socket is
+> typically group-owned (`docker`) with mode `0660`. Because `--user 1000:1000`
+> drops the container's supplementary groups, the process would lack access to the
+> socket and the load would fail with `permission denied`. Adding
+> `--group-add "$(stat -c '%g' /var/run/docker.sock)"` grants exactly that group,
+> and is harmless for a rootless socket (which the user already owns).
+>
+> **Security note — rootful `/var/run/docker.sock`.** When the mounted socket
+> connects to a rootful Docker daemon, `--group-add` gives MCV Docker API access.
+> That access can start privileged containers and mount host paths; `--user` does
+> not reduce these daemon permissions. Use a rootless or isolated daemon, or
+> require trusted images and an isolated runner. Prefer a **rootless Podman**
+> socket (`$XDG_RUNTIME_DIR/podman/podman.sock`) or a rootless Docker socket —
+> neither requires `--group-add` and neither allows privilege escalation through
+> the daemon.
+>
+> **Security note — `seccomp=unconfined` / `apparmor=unconfined`.** MCV runs
+> buildah *inside* the container to assemble the OCI image, which needs
+> `mount`/`unshare`/`pivot_root` and user-namespace operations that Docker's
+> default seccomp and AppArmor profiles block for non-privileged containers.
+> Disabling both is a deliberate, security-reviewed fallback — it is far narrower
+> than `--privileged` (no added capabilities, host devices, or host namespaces),
+> and the blast radius is bounded: the container runs as a non-root user
+> (`--user`), performs a single packaging task, and is removed on exit (`--rm`).
+> To harden the CI job further, replace these flags with scoped seccomp and
+> AppArmor profiles that allow only buildah's required syscalls/operations, or run
+> the same command under **rootless Podman**, which needs neither flag.
 
 ## Performance Comparison
 

--- a/mcv/images/Containerfile
+++ b/mcv/images/Containerfile
@@ -70,13 +70,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv
 COPY mcv/images/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
+
+# Allow non-root user to run commands.
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 and nvcr.io/nvidia/cuda:*-ubuntu24.04 base images). Without this,
+# useradd -u 1000 fails and the silent fallback creates appuser at UID 1001 —
+# K8s runAsUser: 1000 then enters the leftover ubuntu account, not appuser.
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv
+RUN chown appuser:1000 /entrypoint.sh
+# Pre-create buildah's per-user storage so storage.GetStore (running as UID 1000)
+# uses these appuser-owned runroot/graphroot paths instead of trying to create
+# root-owned /run/containers or /var/lib/containers at runtime. Also create
+# ~/.config/containers: when Docker runs the image as the named appuser it sets
+# HOME=/home/appuser, and buildah stats $HOME/.config during setup — it errors
+# if that directory is absent.
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
 
 LABEL description="MCV minimal - cache creation/extraction without GPU libraries (use --no-gpu flag)"
 LABEL variant="minimal"
@@ -93,6 +118,7 @@ CMD ["/mcv"]
 #        mcv --extract --image foo  (with preflight check)
 # ============================================================================
 FROM mcv-minimal AS mcv-amd
+USER root
 
 ARG TARGETARCH
 ARG ROCM_VERSION=7.0.1
@@ -131,6 +157,8 @@ RUN wget -O /tmp/amdgpu-install.deb \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/amdgpu-install.deb
 
+USER appuser
+
 LABEL description="MCV full - includes ROCm libraries for GPU detection and validation"
 LABEL variant="amd"
 
@@ -162,13 +190,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv
 COPY mcv/images/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
+
+# Allow non-root user to run commands.
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 and nvcr.io/nvidia/cuda:*-ubuntu24.04 base images). Without this,
+# useradd -u 1000 fails and the silent fallback creates appuser at UID 1001 —
+# K8s runAsUser: 1000 then enters the leftover ubuntu account, not appuser.
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv
+RUN chown appuser:1000 /entrypoint.sh
+# Pre-create buildah's per-user storage so storage.GetStore (running as UID 1000)
+# uses these appuser-owned runroot/graphroot paths instead of trying to create
+# root-owned /run/containers or /var/lib/containers at runtime. Also create
+# ~/.config/containers: when Docker runs the image as the named appuser it sets
+# HOME=/home/appuser, and buildah stats $HOME/.config during setup — it errors
+# if that directory is absent.
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
 
 LABEL description="MCV NVIDIA - includes CUDA runtime and NVML for GPU detection"
 LABEL variant="nvidia"
@@ -231,13 +284,38 @@ fi
 
 # Configure container storage
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="vfs"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
    > /etc/containers/storage.conf
 
 COPY --from=builder /usr/src/mcv/_output/bin/linux_${TARGETARCH}/mcv /mcv
 COPY mcv/images/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
+
+# Allow non-root user to run commands.
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 and nvcr.io/nvidia/cuda:*-ubuntu24.04 base images). Without this,
+# useradd -u 1000 fails and the silent fallback creates appuser at UID 1001 —
+# K8s runAsUser: 1000 then enters the leftover ubuntu account, not appuser.
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv
+RUN chown appuser:1000 /entrypoint.sh
+# Pre-create buildah's per-user storage so storage.GetStore (running as UID 1000)
+# uses these appuser-owned runroot/graphroot paths instead of trying to create
+# root-owned /run/containers or /var/lib/containers at runtime. Also create
+# ~/.config/containers: when Docker runs the image as the named appuser it sets
+# HOME=/home/appuser, and buildah stats $HOME/.config during setup — it errors
+# if that directory is absent.
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
 
 LABEL description="MCV Unified - includes both NVIDIA (CUDA/NVML) and AMD (ROCm) GPU support for auto-detection"
 LABEL variant="unified"

--- a/mcv/images/Containerfile
+++ b/mcv/images/Containerfile
@@ -36,10 +36,12 @@ RUN set -eux; \
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 
-COPY mcv/ /usr/src/mcv
+COPY mcv/go.mod mcv/go.sum /usr/src/mcv/
 WORKDIR /usr/src/mcv
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+    go mod tidy -v && go mod vendor
 
-RUN make tidy-vendor
+COPY mcv/ /usr/src/mcv/
 RUN make build
 
 # ============================================================================

--- a/mcv/pkg/accelerator/devices/amd.go
+++ b/mcv/pkg/accelerator/devices/amd.go
@@ -121,8 +121,8 @@ type AMDASIC struct {
 
 type AMDBus struct {
 	BDF                  string      `json:"bdf"`
-	MaxPCIeWidth         interface{} `json:"max_pcie_width"`         // Can be int (e.g. 16) or string (e.g. "N/A")
-	MaxPCIeSpeed         interface{} `json:"max_pcie_speed"`         // Can be int or string (e.g. "N/A")
+	MaxPCIeWidth         interface{} `json:"max_pcie_width"` // Can be int (e.g. 16) or string (e.g. "N/A")
+	MaxPCIeSpeed         interface{} `json:"max_pcie_speed"` // Can be int or string (e.g. "N/A")
 	PCIeInterfaceVersion string      `json:"pcie_interface_version"`
 	SlotType             string      `json:"slot_type"`
 }


### PR DESCRIPTION
## Problem:

MCV uses buildah internally to build/push OCI cache images. Buildah traditionally requires `--privileged` because it needs to mount overlay filesystems and run as root. This is a security concern in production Kubernetes and CI environments.

## What changed in the Containerfile

1. Storage driver: FUSE/overlay → VFS (#173)

 driver="vfs"

FUSE-overlayfs requires either --privileged or CAP_SYS_ADMIN + /dev/fuse access. VFS is a naive copy-based storage driver that needs no special kernel capabilities. It's slower (copies instead of overlays), but MCV only builds small single-layer cache images, so the performance difference is negligible.

2. Non-root user (UID/GID 1000)

```
RUN groupadd -g 1000 appgroup && \
    useradd -u 1000 -g appgroup -m -s /bin/bash appuser
USER appuser
```

Running as root inside the container is unnecessary and a security risk. The fixed UID/GID 1000 also makes volume mount permissions predictable.

### Runtime flags: Podman vs Docker

#### Podman:
`podman run -v /path/to/cache:/tests:Z,U <image> ...`

- :Z — relabels the volume for SELinux (private to this container)
- :U — remaps the volume ownership to match the in-container user (UID 1000). Podman runs rootless with user namespaces, so the host UID and container UID differ. :U bridges that gap so appuser can read/write the mount.

You only need :Z,U on volumes the container needs to write to (the cache output directory). Read-only mounts like model files only need :Z (or :ro,Z).

#### Docker:

```
docker run --user $(id -u):$(id -g) \
    --security-opt seccomp=unconfined \
    --security-opt apparmor=unconfined \
    -v /path/to/cache:/tests:Z \
    <image> ...
```

- `--user $(id -u):$(id -g)` — Docker doesn't have Podman's user-namespace remapping, so you explicitly run as your host UID/GID to match volume ownership. Without this, the container runs as UID 1000 (appuser) which may not own the host-side mount.
- `--security-opt seccomp=unconfined` — buildah makes syscalls (like mount, unshare) that Docker's default seccomp profile blocks. Disabling seccomp allows these without granting full --privileged.
- `--security-opt apparmor=unconfined` — on Ubuntu (base container), AppArmor's default Docker profile also blocks some of buildah's mount/namespace operations. Disabling it is the minimal escalation needed.
- `:Z` — SELinux relabeling, same as Podman. No :U needed because --user handles ownership directly.

### Why the difference

Podman is rootless-native — it uses user namespaces automatically, so :U remaps ownership transparently. Docker doesn't do user-namespace remapping by default, so you need --user to align UIDs, and --security-opt to relax seccomp/AppArmor enough for buildah's syscalls without going full --privileged.

### What you're NOT granting

Neither approach uses --privileged. The container does NOT get:

- Full device access
- CAP_SYS_ADMIN
- Host PID/network namespace
- Write access to /dev, /proc, /sys

It's a targeted relaxation: let buildah do its mounts and namespace operations, nothing more.